### PR TITLE
xml-aws-uplift-support

### DIFF
--- a/anysdk/expectedRequest.go
+++ b/anysdk/expectedRequest.go
@@ -10,17 +10,22 @@ type ExpectedRequest interface {
 	GetRequired() []string
 	GetDefault() string
 	GetBase() string
+	GetXMLDeclaration() string
+	GetXMLTransform() string
 	//
 	setSchema(Schema)
 	setBodyMediaType(string)
 }
 
 type standardExpectedRequest struct {
-	BodyMediaType string `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
-	Schema        Schema
-	Default       string   `json:"default,omitempty" yaml:"default,omitempty"`
-	Base          string   `json:"base,omitempty" yaml:"base,omitempty"`
-	Required      []string `json:"required,omitempty" yaml:"required,omitempty"`
+	BodyMediaType     string `json:"mediaType,omitempty" yaml:"mediaType,omitempty"`
+	Schema            Schema
+	Default           string   `json:"default,omitempty" yaml:"default,omitempty"`
+	Base              string   `json:"base,omitempty" yaml:"base,omitempty"`
+	Required          []string `json:"required,omitempty" yaml:"required,omitempty"`
+	XMLDeclaration    string   `json:"xmlDeclaration,omitempty" yaml:"xmlDeclaration,omitempty"`
+	XMLTransform      string   `json:"xmlTransform,omitempty" yaml:"xmlTransform,omitempty"`
+	XMLRootAnnotation string   `json:"xmlRootAnnotation,omitempty" yaml:"xmlRootAnnotation,omitempty"`
 }
 
 func (er *standardExpectedRequest) setBodyMediaType(s string) {
@@ -33,6 +38,14 @@ func (er *standardExpectedRequest) setSchema(s Schema) {
 
 func (er *standardExpectedRequest) GetBodyMediaType() string {
 	return er.BodyMediaType
+}
+
+func (er *standardExpectedRequest) GetXMLDeclaration() string {
+	return er.XMLDeclaration
+}
+
+func (er *standardExpectedRequest) GetXMLTransform() string {
+	return er.XMLTransform
 }
 
 func (er *standardExpectedRequest) GetSchema() Schema {

--- a/anysdk/operation_store.go
+++ b/anysdk/operation_store.go
@@ -29,6 +29,9 @@ import (
 
 const (
 	defaultSelectItemsKey = "items"
+	defaultXMLDeclaration = `<?xml version="1.0" encoding="UTF-8"?>`
+	xmlTransformUnescape  = "unescape"
+	xmlTransformDefault   = xmlTransformUnescape
 )
 
 var (
@@ -124,6 +127,7 @@ type OperationStore interface {
 	getRequestBodyStringifiedPaths() (map[string]struct{}, error)
 	getRequestBodyMediaType() string
 	getRequestBodyMediaTypeNormalised() string
+	getXMLDeclaration() string
 	// getRequestBodyAttributeLineage(string) (string, error)
 }
 
@@ -148,6 +152,36 @@ type standardOperationStore struct {
 	Provider          Provider        `json:"-" yaml:"-"` // upwards traversal
 	Service           Service         `json:"-" yaml:"-"` // upwards traversal
 	Resource          Resource        `json:"-" yaml:"-"` // upwards traversal
+}
+
+func (op *standardOperationStore) getXMLDeclaration() string {
+	rv := ""
+	if op.Request != nil {
+		rv = op.Request.XMLDeclaration
+	}
+	if rv == "" {
+		rv = defaultXMLDeclaration
+	}
+	return rv
+}
+
+func (op *standardOperationStore) getXMLRootAnnotation() string {
+	rv := ""
+	if op.Request != nil {
+		rv = op.Request.XMLRootAnnotation
+	}
+	return rv
+}
+
+func (op *standardOperationStore) getXMLTransform() string {
+	rv := ""
+	if op.Request != nil {
+		rv = op.Request.XMLTransform
+	}
+	if rv == "" {
+		rv = xmlTransformDefault
+	}
+	return rv
 }
 
 func (op *standardOperationStore) getRequestBodyStringifiedPaths() (map[string]struct{}, error) {
@@ -1044,7 +1078,13 @@ func (op *standardOperationStore) marshalBody(body interface{}, expectedRequest 
 	case media.MediaTypeJson:
 		return json.Marshal(body)
 	case media.MediaTypeXML, media.MediaTypeTextXML:
-		return xmlmap.MarshalXMLUserInput(body, expectedRequest.GetSchema().getXMLALiasOrName(), "unescape")
+		return xmlmap.MarshalXMLUserInput(
+			body,
+			expectedRequest.GetSchema().getXMLALiasOrName(),
+			op.getXMLTransform(),
+			op.getXMLDeclaration(),
+			op.getXMLRootAnnotation(),
+		)
 	}
 	return nil, fmt.Errorf("media type = '%s' not supported", expectedRequest.GetBodyMediaType())
 }

--- a/pkg/xmlmap/xmlmap.go
+++ b/pkg/xmlmap/xmlmap.go
@@ -318,7 +318,7 @@ func unescapeXML(input []byte) ([]byte, error) {
 	return rv, nil
 }
 
-func MarshalXMLUserInput(input interface{}, enclosingName string, transformName string) ([]byte, error) {
+func MarshalXMLUserInput(input interface{}, enclosingName string, transformName string, xmlDeclaration string, enclosingNameAnnotation string) ([]byte, error) {
 	switch input := input.(type) {
 	case map[string]interface{}:
 		m := newPermissableMapWrapper(input, enclosingName)
@@ -327,7 +327,19 @@ func MarshalXMLUserInput(input interface{}, enclosingName string, transformName 
 			return nil, marshallErr
 		}
 		if transformName != "" {
-			return unescapeXML(marshalled)
+			var unescapeErr error
+			marshalled, unescapeErr = unescapeXML(marshalled)
+			if unescapeErr != nil {
+				return nil, unescapeErr
+			}
+		}
+		if xmlDeclaration != "" {
+			marshalled = []byte(fmt.Sprintf("%s%s", xmlDeclaration, marshalled))
+		}
+		if enclosingNameAnnotation != "" {
+			replacementStr := fmt.Sprintf("%s %s", enclosingName, enclosingNameAnnotation)
+			newStr := strings.Replace(string(marshalled), enclosingName, replacementStr, 1)
+			marshalled = []byte(newStr)
 		}
 		return marshalled, nil
 	default:

--- a/pkg/xmlmap/xmlmap_test.go
+++ b/pkg/xmlmap/xmlmap_test.go
@@ -49,8 +49,8 @@ func TestXMLMArshal(t *testing.T) {
 	input := map[string]interface{}{
 		"XX": "yy",
 	}
-	b, err := MarshalXMLUserInput(input, "Input", "")
+	b, err := MarshalXMLUserInput(input, "Input", "", "", `xmlns="https://route53.amazonaws.com/doc/2013-04-01/"`)
 	assert.NilError(t, err)
 	s := string(b)
-	assert.Assert(t, s == "<Input><XX>yy</XX></Input>")
+	assert.Assert(t, s == `<Input xmlns="https://route53.amazonaws.com/doc/2013-04-01/"><XX>yy</XX></Input>`)
 }


### PR DESCRIPTION
Summary:

- Defaulted, configurable `xml` declaration for `xml` request bodies.
- Configurable xml namespace and other attributes for root element.