### PR TITLE
http-status-error-reponse-handling

### DIFF
--- a/pkg/response/response.go
+++ b/pkg/response/response.go
@@ -22,15 +22,18 @@ type Response interface {
 	GetProcessedBody() interface{}
 	ExtractElement(e httpelement.HTTPElement) (interface{}, error)
 	Error() string
+	HasError() bool
+	SetError(string)
 	String() string
 }
 
 type basicResponse struct {
-	_             struct{}
-	rawBody       interface{}
-	processedBody interface{}
-	httpResponse  *http.Response
-	bodyMediaType string
+	_                   struct{}
+	rawBody             interface{}
+	processedBody       interface{}
+	httpResponse        *http.Response
+	bodyMediaType       string
+	errorStringOverride string
 }
 
 func (r *basicResponse) GetHttpResponse() *http.Response {
@@ -43,6 +46,10 @@ func (r *basicResponse) GetBody() interface{} {
 
 func (r *basicResponse) GetProcessedBody() interface{} {
 	return r.processedBody
+}
+
+func (r *basicResponse) HasError() bool {
+	return r.errorStringOverride != ""
 }
 
 func (r *basicResponse) String() string {
@@ -74,7 +81,14 @@ func (r *basicResponse) string() string {
 	return ""
 }
 
+func (r *basicResponse) SetError(err string) {
+	r.errorStringOverride = err
+}
+
 func (r *basicResponse) Error() string {
+	if r.errorStringOverride != "" {
+		return r.errorStringOverride
+	}
 	baseString := r.string()
 	if baseString != "" {
 		return fmt.Sprintf(`{ "httpError": %s }`, baseString)


### PR DESCRIPTION
Summary:

- Publish http status code and message in http status code >= 300 scenarios.
- Permit developer anomalies.
- Invariant: if json enpoint returns json, then it is retained as a raw response.
- Handle nil response body error.