### PR TITLE
lite-templates

### DIFF
--- a/anysdk/auth_dto.go
+++ b/anysdk/auth_dto.go
@@ -40,6 +40,8 @@ type AuthDTO interface {
 	GetGrantType() string
 	GetValues() url.Values
 	GetAuthStyle() int
+	GetAccountID() string
+	GetAccountIDEnvVar() string
 }
 
 type standardAuthDTO struct {
@@ -71,6 +73,16 @@ type standardAuthDTO struct {
 	Values             url.Values       `json:"values,omitempty" yaml:"values,omitempty"`
 	Location           string           `json:"location,omitempty" yaml:"location,omitempty"`
 	AuthStyle          int              `json:"auth_style" yaml:"auth_style"`
+	AccoountID         string           `json:"account_id" yaml:"account_id"`
+	AccountIDEnvVar    string           `json:"account_id_env_var" yaml:"account_id_var"`
+}
+
+func (qt standardAuthDTO) GetAccountID() string {
+	return qt.AccoountID
+}
+
+func (qt standardAuthDTO) GetAccountIDEnvVar() string {
+	return qt.AccountIDEnvVar
 }
 
 func (qt standardAuthDTO) GetValues() url.Values {

--- a/pkg/litetemplate/litetemplate.go
+++ b/pkg/litetemplate/litetemplate.go
@@ -1,0 +1,72 @@
+package litetemplate
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+)
+
+const (
+	EnvPrefix string = "__env__"
+)
+
+func RenderTemplateFromSerializable(templateString string, data interface{}) (string, error) {
+	b, err := json.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	var m map[string]interface{}
+	err = json.Unmarshal(b, &m)
+	if err != nil {
+		return "", err
+	}
+	for _, keyVal := range os.Environ() {
+		kv := strings.SplitN(keyVal, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		m[fmt.Sprintf("%s%s", EnvPrefix, kv[0])] = kv[1]
+	}
+	return renderTemplate(templateString, m)
+}
+
+func renderTemplate(templateString string, data interface{}) (string, error) {
+	liteTmpl, newErr := newLiteTemplate()
+	if newErr != nil {
+		return "", newErr
+	}
+	return liteTmpl.render(templateString, data)
+}
+
+type liteTemplate struct {
+}
+
+func (lt *liteTemplate) generate(templateString string) (*template.Template, error) {
+	tmpl, err := template.New("example").
+		// Delims("{", "}").
+		Parse(templateString)
+	if err != nil {
+		return nil, err
+	}
+	return tmpl, nil
+}
+
+func (lt *liteTemplate) render(templateString string, data interface{}) (string, error) {
+	var buf bytes.Buffer
+	tmpl, err := lt.generate(templateString)
+	if err != nil {
+		return "", err
+	}
+	exErr := tmpl.Execute(&buf, data)
+	if err != nil {
+		return "", exErr
+	}
+	return buf.String(), nil
+}
+
+func newLiteTemplate() (*liteTemplate, error) {
+	return &liteTemplate{}, nil
+}

--- a/pkg/litetemplate/litetemplate_test.go
+++ b/pkg/litetemplate/litetemplate_test.go
@@ -1,0 +1,135 @@
+package litetemplate_test
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/stackql/any-sdk/pkg/litetemplate"
+	"gotest.tools/assert"
+)
+
+func TestRenderTemplate(t *testing.T) {
+	t.Parallel()
+	templateString := `{{.Name}}`
+	data := struct {
+		Name string
+	}{
+		Name: "example",
+	}
+	expected := "example"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRenderEnvTemplate(t *testing.T) {
+	os.Unsetenv("UNIT_TEST_MY_SILLY_NAME")
+	os.Setenv("UNIT_TEST_MY_SILLY_NAME", "some_example")
+	t.Parallel()
+	templateString := `{{ .__env__UNIT_TEST_MY_SILLY_NAME }}`
+	data := map[string]interface{}{}
+	expected := "some_example"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRenderEnvTemplateExotic(t *testing.T) {
+	os.Unsetenv("_UNIT_TEST_MY_SILLY_NAME")
+	os.Setenv("_UNIT_TEST_MY_SILLY_NAME", "Welcome to the sunlight")
+	t.Parallel()
+	templateString := `{{ .message }}: {{ .__env___UNIT_TEST_MY_SILLY_NAME }}`
+	data := map[string]interface{}{
+		"message": "hello, here is my env var dereferenced",
+	}
+	expected := "hello, here is my env var dereferenced: Welcome to the sunlight"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRenderEnvURLTemplateExotic(t *testing.T) {
+	os.Setenv("_UNIT_TEST_MY_HOST_NAME", "my.domain.com")
+	os.Setenv("_UNIT_TEST_MY_LHS_SUB_PATH", "system")
+	os.Setenv("_UNIT_TEST_MY_RHS_SUB_PATH", "identity/rules/share")
+	t.Parallel()
+	templateString := `{{ .protocol }}://{{ .__env___UNIT_TEST_MY_HOST_NAME }}/{{ .__env___UNIT_TEST_MY_LHS_SUB_PATH }}/{{ .__env___UNIT_TEST_MY_RHS_SUB_PATH }}{{ .suffix }}`
+	data := map[string]interface{}{
+		"protocol": "https",
+		"suffix":   "?a=1&b=2",
+	}
+	expected := "https://my.domain.com/system/identity/rules/share?a=1&b=2"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+
+	os.Unsetenv("_UNIT_TEST_MY_HOST_NAME")
+	os.Unsetenv("_UNIT_TEST_MY_LHS_SUB_PATH")
+	os.Unsetenv("_UNIT_TEST_MY_RHS_SUB_PATH")
+
+}
+
+func TestRenderTemplateFromSerializable(t *testing.T) {
+	t.Parallel()
+	type testingStructure struct {
+		SomeOtherName string `json:"my_var" yaml:"my_var"`
+	}
+	templateString := `{{.my_var}}`
+	var data testingStructure
+	json.Unmarshal([]byte(`{"my_var":"example"}`), &data)
+	expected := "example"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRenderURLTemplateFromSerializable(t *testing.T) {
+	t.Parallel()
+	type testingStructure struct {
+		SomeOtherName string `json:"my_var" yaml:"my_var"`
+	}
+	templateString := `https://example.com/{{.my_var}}/token`
+	var data testingStructure
+	json.Unmarshal([]byte(`{"my_var":"example"}`), &data)
+	expected := "https://example.com/example/token"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+func TestRenderNilURLTemplateFromSerializable(t *testing.T) {
+	t.Parallel()
+	type testingStructure struct {
+		SomeOtherName string `json:"my_var" yaml:"my_var"`
+	}
+	templateString := `https://example.com/`
+	var data testingStructure
+	json.Unmarshal([]byte(`{"my_var":"example"}`), &data)
+	expected := "https://example.com/"
+	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+	assert.NilError(t, err)
+	assert.Equal(t, expected, actual)
+}
+
+// func TestRenderErroneousTemplateFromSerializable(t *testing.T) {
+// 	t.Parallel()
+// 	type testingStructure struct {
+// 		SomeOtherName string `json:"my_var" yaml:"my_var"`
+// 	}
+// 	templateString := `{{.non_existent_var}}`
+// 	var data testingStructure
+// 	json.Unmarshal([]byte(`{"my_var":"example"}`), &data)
+// 	expected := "example"
+// 	actual, err := litetemplate.RenderTemplateFromSerializable(templateString, data)
+
+// 	assert.ErrorContains(t, err, "expected string")
+// 	assert.Equal(t, expected, actual)
+// }


### PR DESCRIPTION
## Summary

- `litetemplate` package for:
    - Inline templating to be used by data transfer objects. Eg `{{ .my_attribute  }}` will dereference vallue serialized at `my_attribute` in given structure.
    - Reading from environment using the prefix `__env__`; eg: `{{ .__env__MY_VAR }}` will dereference the env var `MY_VAR`.
- Auth DTO now supports `account_id` and `account_id_env_var` attributes.  These are not standards-aligned, semantics can vary.