### PR TITLE
aws-ec2-instances-exec

### DIFF
--- a/anysdk/schema.go
+++ b/anysdk/schema.go
@@ -111,9 +111,9 @@ func providerTypeConditionIsValid(providerType string, lhs string, rhs interface
 	case "string":
 		return reflect.TypeOf(rhs).String() == "string"
 	case "object":
-		return false
+		return reflect.TypeOf(rhs).String() == "string"
 	case "array":
-		return false
+		return reflect.TypeOf(rhs).String() == "string"
 	case "int", "int32", "int64":
 		return reflect.TypeOf(rhs).String() == "int"
 	default:


### PR DESCRIPTION
## Summary

- Loosen type checking.
- Support `aws.ec2.instances` exec.