### PR TITLE
cli-api-calls

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,8 @@ env:
   GH_ACCESS_TOKEN: ${{ secrets.ACTIONS_PRIVATE_PACKAGE_SECRET }}
   PLANCACHEENABLED: "true"
   GOLANG_VERSION: 1.22
+  STACKQL_CORE_REPOSITORY: ${{ vars.STACKQL_CORE_REPOSITORY != '' && vars.STACKQL_CORE_REPOSITORY || 'stackql/stackql' }}
+  STACKQL_CORE_REF: ${{ vars.STACKQL_CORE_REF != '' && vars.STACKQL_CORE_REF || 'main' }}
 
 jobs:
 
@@ -92,6 +94,12 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+    
+    - name: Setup Python
+      uses: actions/setup-python@v5.0.0
+      with:
+        # cache: pip # this requires requirements in source control
+        python-version: '3.11' 
       
     - name: Get dependencies
       run: |
@@ -124,17 +132,61 @@ jobs:
       if: success()
       run: go test -timeout 240s -v ./...
     
-    - name: CLI Test
+    - name: Trivial CLI Test
       if: success()
       run: |
         sudo apt-get update
         sudo apt-get install -y jq
         result="$(build/anysdk const | jq -r '.ExtensionKeyAlwaysRequired')"
         if [ "$result" != "x-alwaysRequired" ]; then
-          echo "CLI Test Failed with unexpected result: $result"
+          echo "Trivial CLI Test Failed with unexpected result: $result"
           exit 1
         else
-          echo "CLI Test passed with expected result: $result"
+          echo "Trivial CLI Test passed with expected result: $result"
+        fi
+
+    - name: Download core
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ env.STACKQL_CORE_REPOSITORY }}
+        ref: ${{ env.STACKQL_CORE_REF }}
+        path: stackql-core
+    
+    - name: Create materials for core tests
+      working-directory: stackql-core
+      run: |
+        pip3 install -r cicd/requirements.txt
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_server_key.pem -out test/server/mtls/credentials/pg_server_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_client_key.pem -out test/server/mtls/credentials/pg_client_cert.pem -config test/server/mtls/openssl.cnf -days 365
+        openssl req -x509 -keyout test/server/mtls/credentials/pg_rubbish_key.pem -out test/server/mtls/credentials/pg_rubbish_cert.pem -config test/server/mtls/openssl.cnf -days 365 
+        python3 test/python/registry-rewrite.py
+    
+    - name: Start Core Test Mocks
+      working-directory: stackql-core
+      run: |
+        pgrep -f flask | xargs kill -9 || true
+        flask --app=./test/python/flask/gcp/app          run --cert=./test/server/mtls/credentials/pg_server_cert.pem --key=./test/server/mtls/credentials/pg_server_key.pem --host 0.0.0.0 --port 1080 & 
+        # Lack of TLS on token server should be addressed universally
+        flask --app=./test/python/flask/oauth2/token_srv run --host 0.0.0.0 --port 2091 & 
+    
+    - name: Run core mocked testing
+      working-directory: stackql-core
+      run: |
+        export GCP_SERVICE_ACCOUNT_KEY="$(cat test/assets/credentials/dummy/google/functional-test-dummy-sa-key.json)"
+        bucketsListIDs="$(${{ github.workspace }}/build/anysdk query \
+          --svc-file-path="test/registry-mocked/src/googleapis.com/v0.1.2/services/storage-v1.yaml" \
+          --tls.allowInsecure \
+          --prov-file-path="test/registry-mocked/src/googleapis.com/v0.1.2/provider.yaml" \
+          --resource buckets \
+          --method list \
+          --parameters '{ "project": "stackql-demo" }' \
+          | jq -r '.items[].id')" 
+        matchingBuckets="$(echo "${bucketsListIDs}" | grep "stackql-demo" )"
+        if [ "${matchingBuckets}" = "" ]; then
+          echo "Core Test Failed with no matching buckets"
+          exit 1
+        else
+          echo "Core Test passed with matching buckets: $matchingBuckets"
         fi
 
   macosbuild:

--- a/anysdk/loader.go
+++ b/anysdk/loader.go
@@ -40,6 +40,7 @@ type DiscoveryDoc interface {
 
 type Loader interface {
 	LoadFromBytes(bytes []byte) (Service, error)
+	LoadFromBytesWithProvider(bytes []byte, prov Provider) (Service, error)
 	LoadFromBytesAndResources(rr ResourceRegister, resourceKey string, bytes []byte) (Service, error)
 	//
 	extractAndMergeQueryTransposeServiceLevel(svc Service) error
@@ -85,6 +86,15 @@ func (l *standardLoader) LoadFromBytes(bytes []byte) (Service, error) {
 	if err != nil {
 		return nil, err
 	}
+	return svc, nil
+}
+
+func (l *standardLoader) LoadFromBytesWithProvider(bytes []byte, prov Provider) (Service, error) {
+	svc, err := l.LoadFromBytes(bytes)
+	if err != nil {
+		return nil, err
+	}
+	svc.setProvider(prov)
 	return svc, nil
 }
 

--- a/cicd/keys/.gitignore
+++ b/cicd/keys/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/cicd/staging/.gitignore
+++ b/cicd/staging/.gitignore
@@ -1,0 +1,3 @@
+*
+!README.md
+!.gitignore

--- a/cicd/staging/README.md
+++ b/cicd/staging/README.md
@@ -1,0 +1,7 @@
+
+## Staging directory
+
+A working directory for download of software for use in CICD.
+
+All items execpt this file should remain `.gitignore`d.
+

--- a/cmd/argparse/argparse.go
+++ b/cmd/argparse/argparse.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/stackql/any-sdk/pkg/dto"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -21,13 +22,8 @@ var (
 
 var SemVersion string = fmt.Sprintf("%s.%s.%s", BuildMajorVersion, BuildMinorVersion, BuildPatchVersion)
 
-type runtimeContext struct {
-	CPUProfile  string
-	LogLevelStr string
-}
-
 var (
-	runtimeCtx      runtimeContext
+	runtimeCtx      dto.RuntimeCtx
 	replicateCtrMgr bool = false
 )
 
@@ -61,10 +57,21 @@ func init() {
 	// will be global for your application.
 
 	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CPUProfile, "cpuprofile", "", "cpuprofile file, none if empty")
-	rootCmd.PersistentFlags().StringVar(&runtimeCtx.LogLevelStr, "loglevel", "warn", "loglevel")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.LogLevelStr, "loglevel", "warn", "specify a canonical log level")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.AuthRaw, "auth", `{}`, "auth maps json string, keys are provider names")
+	rootCmd.PersistentFlags().BoolVar(&runtimeCtx.AllowInsecure, dto.AllowInsecureKey, false, "Allow trust of insecure certificates (not recommended)")
+	// CLI specific flags
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIPayload, "payload", ``, "string payload eg for HTTP request body")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIPayloadType, "payload-type", `application/json`, "request payload type, eg HTTP request Content-Type such as application/json")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIParameters, "parameters", `{}`, "json string of parameter map")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIProvFilePath, "prov-file-path", ``, "path to provider definition file")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLISvcFilePath, "svc-file-path", ``, "path to service definition file")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIResourceStr, "resource", ``, "resource name")
+	rootCmd.PersistentFlags().StringVar(&runtimeCtx.CLIMethodName, "method", ``, "method name")
 
 	rootCmd.AddCommand(execCmd)
 	rootCmd.AddCommand(constCmd)
+	rootCmd.AddCommand(queryCmd)
 
 }
 

--- a/cmd/argparse/const.go
+++ b/cmd/argparse/const.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stackql/any-sdk/anysdk"
+	"github.com/stackql/any-sdk/pkg/dto"
 )
 
 // execCmd represents the exec command
@@ -36,7 +37,7 @@ var constCmd = &cobra.Command{
 	},
 }
 
-func runConstCommand(rtCtx runtimeContext) {
+func runConstCommand(rtCtx dto.RuntimeCtx) {
 	constMap := map[string]interface{}{
 		"ExtensionKeyAlwaysRequired": anysdk.ExtensionKeyAlwaysRequired,
 	}

--- a/cmd/argparse/query.go
+++ b/cmd/argparse/query.go
@@ -1,0 +1,371 @@
+package argparse
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"runtime/pprof"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v2"
+
+	"github.com/stackql/any-sdk/anysdk"
+	"github.com/stackql/any-sdk/pkg/auth_util"
+	"github.com/stackql/any-sdk/pkg/constants"
+	"github.com/stackql/any-sdk/pkg/dto"
+	"github.com/stackql/any-sdk/pkg/internaldto"
+	"github.com/stackql/any-sdk/pkg/netutils"
+)
+
+type genericProvider struct {
+	provider   anysdk.Provider
+	runtimeCtx dto.RuntimeCtx
+	authUtil   auth_util.AuthUtility
+}
+
+func newGenericProvider(rtCtx dto.RuntimeCtx, prov anysdk.Provider) *genericProvider {
+	return &genericProvider{
+		runtimeCtx: rtCtx,
+		authUtil:   auth_util.NewAuthUtility(),
+		provider:   prov,
+	}
+}
+
+func (gp *genericProvider) inferAuthType(authCtx dto.AuthCtx, authTypeRequested string) string {
+	ft := strings.ToLower(authTypeRequested)
+	switch ft {
+	case dto.AuthAzureDefaultStr:
+		return dto.AuthAzureDefaultStr
+	case dto.AuthAPIKeyStr:
+		return dto.AuthAPIKeyStr
+	case dto.AuthBasicStr:
+		return dto.AuthBasicStr
+	case dto.AuthBearerStr:
+		return dto.AuthBearerStr
+	case dto.AuthServiceAccountStr:
+		return dto.AuthServiceAccountStr
+	case dto.AuthInteractiveStr:
+		return dto.AuthInteractiveStr
+	case dto.AuthNullStr:
+		return dto.AuthNullStr
+	case dto.AuthAWSSigningv4Str:
+		return dto.AuthAWSSigningv4Str
+	case dto.AuthCustomStr:
+		return dto.AuthCustomStr
+	case dto.OAuth2Str:
+		return dto.OAuth2Str
+	}
+	if authCtx.KeyFilePath != "" || authCtx.KeyEnvVar != "" {
+		return dto.AuthServiceAccountStr
+	}
+	return dto.AuthNullStr
+}
+
+func (gp *genericProvider) Auth(
+	authCtx *dto.AuthCtx,
+	authTypeRequested string,
+	enforceRevokeFirst bool,
+) (*http.Client, error) {
+	authCtx = authCtx.Clone()
+	at := gp.inferAuthType(*authCtx, authTypeRequested)
+	switch at {
+	case dto.AuthAPIKeyStr:
+		return gp.authUtil.ApiTokenAuth(authCtx, gp.runtimeCtx, false)
+	case dto.AuthBearerStr:
+		return gp.authUtil.ApiTokenAuth(authCtx, gp.runtimeCtx, true)
+	case dto.AuthServiceAccountStr:
+		scopes := authCtx.Scopes
+		return gp.authUtil.GoogleOauthServiceAccount(gp.provider.GetName(), authCtx, scopes, gp.runtimeCtx)
+	case dto.OAuth2Str:
+		if authCtx.GrantType == dto.ClientCredentialsStr {
+			scopes := authCtx.Scopes
+			return gp.authUtil.GenericOauthClientCredentials(authCtx, scopes, gp.runtimeCtx)
+		}
+	case dto.AuthBasicStr:
+		return gp.authUtil.BasicAuth(authCtx, gp.runtimeCtx)
+	case dto.AuthCustomStr:
+		return gp.authUtil.CustomAuth(authCtx, gp.runtimeCtx)
+	case dto.AuthAzureDefaultStr:
+		return gp.authUtil.AzureDefaultAuth(authCtx, gp.runtimeCtx)
+	case dto.AuthInteractiveStr:
+		return gp.authUtil.GCloudOAuth(gp.runtimeCtx, authCtx, enforceRevokeFirst)
+	case dto.AuthAWSSigningv4Str:
+		return gp.authUtil.AwsSigningAuth(authCtx, gp.runtimeCtx)
+	case dto.AuthNullStr:
+		return netutils.GetHTTPClient(gp.runtimeCtx, http.DefaultClient), nil
+	}
+	return nil, fmt.Errorf("could not infer auth type")
+}
+
+func getLogger() *logrus.Logger {
+	logger := logrus.New()
+	logger.SetOutput(os.Stderr)
+	logger.SetLevel(logrus.WarnLevel)
+	return logger
+}
+
+func parseExecPayload(
+	payload string,
+	payloadType string,
+) (internaldto.ExecPayload, error) {
+	payloadBytes := []byte(payload)
+	m := make(map[string][]string)
+	pm := map[string]interface{}{}
+	switch payloadType {
+	case constants.JSONStr, "application/json":
+		if len(payloadBytes) > 0 {
+			m["Content-Type"] = []string{"application/json"}
+			err := json.Unmarshal(payloadBytes, &pm)
+			if err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("payload map of declared type = '%T' not allowed", payloadType)
+	}
+	return internaldto.NewExecPayload(
+		payloadBytes,
+		m,
+		pm,
+	), nil
+}
+
+type queryCmdPayload struct {
+	rtCtx        dto.RuntimeCtx
+	provFilePath string
+	svcFilePath  string
+	resourceStr  string
+	methodName   string
+	payload      string
+	payloadType  string
+	parameters   map[string]interface{}
+	auth         map[string]*dto.AuthCtx
+}
+
+func (qcp *queryCmdPayload) getService() (anysdk.Service, error) {
+	pb, err := os.ReadFile(qcp.provFilePath)
+	if err != nil {
+		return nil, err
+	}
+	prov, err := anysdk.LoadProviderDocFromBytes(pb)
+	if err != nil {
+		return nil, err
+	}
+	b, err := os.ReadFile(qcp.svcFilePath)
+	if err != nil {
+		return nil, err
+	}
+	l := anysdk.NewLoader()
+	svc, err := l.LoadFromBytesWithProvider(b, prov)
+	if err != nil {
+		return nil, err
+	}
+	return svc, nil
+}
+
+func (qcp *queryCmdPayload) getProvider() (anysdk.Provider, error) {
+	pb, err := os.ReadFile(qcp.provFilePath)
+	if err != nil {
+		return nil, err
+	}
+	prov, err := anysdk.LoadProviderDocFromBytes(pb)
+	if err != nil {
+		return nil, err
+	}
+	return prov, nil
+}
+
+func newQueryCmdPayload(rtCtx dto.RuntimeCtx) (*queryCmdPayload, error) {
+	var params map[string]interface{}
+	err := json.Unmarshal([]byte(rtCtx.CLIParameters), &params)
+	if err != nil {
+		return nil, err
+	}
+	ac := make(map[string]*dto.AuthCtx)
+	err = yaml.Unmarshal([]byte(runtimeCtx.AuthRaw), ac)
+	if err != nil {
+		return nil, err
+	}
+	return &queryCmdPayload{
+		rtCtx:        rtCtx,
+		svcFilePath:  rtCtx.CLISvcFilePath,
+		provFilePath: rtCtx.CLIProvFilePath,
+		resourceStr:  rtCtx.CLIResourceStr,
+		methodName:   rtCtx.CLIMethodName,
+		payload:      rtCtx.CLIPayload,
+		payloadType:  rtCtx.CLIPayloadType,
+		parameters:   params,
+		auth:         ac,
+	}, nil
+}
+
+func runQueryCommand(gp *genericProvider, authCtx *dto.AuthCtx, payload *queryCmdPayload) error {
+	prov, err := payload.getProvider()
+	if err != nil {
+		return err
+	}
+	svc, err := payload.getService()
+	if err != nil {
+		return err
+	}
+	res, err := svc.GetResource(payload.resourceStr)
+	if err != nil {
+		return err
+	}
+	opStore, err := res.FindMethod(payload.methodName)
+	if err != nil {
+		return err
+	}
+	execPayload, err := parseExecPayload(
+		payload.payload,
+		payload.payloadType,
+	)
+	if err != nil {
+		return err
+	}
+	execCtx := anysdk.NewExecContext(
+		execPayload,
+		res,
+	)
+	prep := anysdk.NewHTTPPreparator(
+		prov,
+		svc,
+		opStore,
+		map[int]map[string]interface{}{
+			0: payload.parameters,
+		},
+		nil,
+		execCtx,
+		getLogger(),
+	)
+	httpClient, err := gp.Auth(
+		authCtx,
+		authCtx.Type,
+		false,
+	)
+	if err != nil {
+		return err
+	}
+	armoury, err := prep.BuildHTTPRequestCtx()
+	if err != nil {
+		return err
+	}
+	for _, v := range armoury.GetRequestParams() {
+		req := v.GetRequest()
+		response, err := httpClient.Do(req)
+		if err != nil {
+			return err
+		}
+		defer response.Body.Close()
+		bodyBytes, err := io.ReadAll(response.Body)
+		if err != nil {
+			return err
+		}
+		fmt.Fprintf(os.Stdout, "%s", string(bodyBytes))
+	}
+	return nil
+}
+
+func transformOpenapiStackqlAuthToLocal(authDTO anysdk.AuthDTO) *dto.AuthCtx {
+	rv := &dto.AuthCtx{
+		Scopes:                  authDTO.GetScopes(),
+		Subject:                 authDTO.GetSubject(),
+		Type:                    authDTO.GetType(),
+		ValuePrefix:             authDTO.GetValuePrefix(),
+		KeyID:                   authDTO.GetKeyID(),
+		KeyIDEnvVar:             authDTO.GetKeyIDEnvVar(),
+		KeyFilePath:             authDTO.GetKeyFilePath(),
+		KeyFilePathEnvVar:       authDTO.GetKeyFilePathEnvVar(),
+		KeyEnvVar:               authDTO.GetKeyEnvVar(),
+		EnvVarAPIKeyStr:         authDTO.GetEnvVarAPIKeyStr(),
+		EnvVarAPISecretStr:      authDTO.GetEnvVarAPISecretStr(),
+		EnvVarUsername:          authDTO.GetEnvVarUsername(),
+		EnvVarPassword:          authDTO.GetEnvVarPassword(),
+		EncodedBasicCredentials: authDTO.GetInlineBasicCredentials(),
+		Location:                authDTO.GetLocation(),
+		Name:                    authDTO.GetName(),
+		TokenURL:                authDTO.GetTokenURL(),
+		GrantType:               authDTO.GetGrantType(),
+		ClientID:                authDTO.GetClientID(),
+		ClientSecret:            authDTO.GetClientSecret(),
+		ClientIDEnvVar:          authDTO.GetClientIDEnvVar(),
+		ClientSecretEnvVar:      authDTO.GetClientSecretEnvVar(),
+		Values:                  authDTO.GetValues(),
+		AuthStyle:               authDTO.GetAuthStyle(),
+		AccountID:               authDTO.GetAccountID(),
+		AccoountIDEnvVar:        authDTO.GetAccountIDEnvVar(),
+	}
+	successor, successorExists := authDTO.GetSuccessor()
+	currentParent := rv
+	for {
+		if successorExists {
+			transformedSuccessor := transformOpenapiStackqlAuthToLocal(successor)
+			currentParent.Successor = transformedSuccessor
+			currentParent = transformedSuccessor
+			successor, successorExists = successor.GetSuccessor()
+		} else {
+			break
+		}
+	}
+	return rv
+}
+
+// queryCmd represents the query command
+var queryCmd = &cobra.Command{
+	Use:   "query",
+	Short: "Simple provider query",
+	Long:  `Simple provider query`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if runtimeCtx.CPUProfile != "" {
+			f, err := os.Create(runtimeCtx.CPUProfile)
+			if err != nil {
+				printErrorAndExitOneIfError(err)
+			}
+			pprof.StartCPUProfile(f)
+			defer pprof.StopCPUProfile()
+		}
+
+		// if len(args) == 0 || args[0] == "" {
+		// 	cmd.Help()
+		// 	os.Exit(0)
+		// }
+
+		payload, err := newQueryCmdPayload(runtimeCtx)
+
+		printErrorAndExitOneIfError(err)
+
+		prov, err := payload.getProvider()
+
+		printErrorAndExitOneIfError(err)
+
+		provStr := prov.GetName()
+
+		printErrorAndExitOneIfError(err)
+
+		gp := newGenericProvider(runtimeCtx, prov)
+
+		auth, isAuthPresent := payload.auth[provStr]
+
+		if !isAuthPresent {
+			authDTO, isAuthPresent := prov.GetAuth()
+			if !isAuthPresent {
+				printErrorAndExitOneIfError(fmt.Errorf("auth not present"))
+			}
+			auth = transformOpenapiStackqlAuthToLocal(authDTO)
+		}
+
+		err = runQueryCommand(
+			gp,
+			auth,
+			payload,
+		)
+
+		printErrorAndExitOneIfError(err)
+
+	},
+}

--- a/cmd/argparse/read.go
+++ b/cmd/argparse/read.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/stackql/any-sdk/anysdk"
+	"github.com/stackql/any-sdk/pkg/dto"
 )
 
 func printErrorAndExitOneIfNil(subject interface{}, msg string) {
@@ -49,7 +50,7 @@ var execCmd = &cobra.Command{
 	},
 }
 
-func runReadCommand(rtCtx runtimeContext, arg string) {
+func runReadCommand(rtCtx dto.RuntimeCtx, arg string) {
 	b, err := os.ReadFile(arg)
 	printErrorAndExitOneIfError(err)
 	l := anysdk.NewLoader()

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3,3 +3,52 @@
 
 The `any-sdk` CLI is for testing purposes, so long as semver < 1.
 
+
+## Build
+
+From the root of this repository:
+
+```bash
+cicd/cli/build_cli.sh
+```
+
+This creates an executable at the `.gitignore`d location `build/anysdk`.
+
+
+## Examples
+
+### Const
+
+The `const` command is very much a trivial "Hello World":
+
+```bash
+./build/anysdk const
+{"ExtensionKeyAlwaysRequired":"x-alwaysRequired"}
+```
+
+### Query
+
+
+```bash
+
+export GOOGLE_CREDENTIALS="$(cat cicd/keys/google-ro-credentials.json)"
+
+
+./build/anysdk query \
+  --svc-file-path="test/tmp/googleapis.com/v24.11.00274/services/compute.yaml" \
+  --prov-file-path="test/tmp/googleapis.com/v24.11.00274/provider.yaml" \
+  --resource accelerator_types \
+  --method aggregated_list \
+  --parameters '{ "project": "stackql-demo" }' \
+  | jq -r '.items["zones/us-east7-b"]'
+
+
+./build/anysdk query \
+  --svc-file-path="test/tmp/googleapis.com/v24.11.00274/services/storage.yaml" \
+  --prov-file-path="test/tmp/googleapis.com/v24.11.00274/provider.yaml" \
+  --resource buckets \
+  --method list \
+  --parameters '{ "project": "stackql-demo" }' \
+  | jq -r '.items[].id'
+
+```

--- a/pkg/dto/runtime_ctx.go
+++ b/pkg/dto/runtime_ctx.go
@@ -55,6 +55,13 @@ type RuntimeCtx struct {
 	VerboseFlag                  bool
 	ViperCfgFileName             string
 	WorkOffline                  bool
+	CLIPayload                   string
+	CLIPayloadType               string
+	CLIParameters                string
+	CLIProvFilePath              string
+	CLISvcFilePath               string
+	CLIResourceStr               string
+	CLIMethodName                string
 }
 
 func setInt(iPtr *int, val string) error {

--- a/test/tmp/.gitignore
+++ b/test/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary

- Support for CLI to query arbitrary endpoints.
- Simple parameterised query working manually.
- Leverage provider and service docs to make authenticated `any-cli` API calls.
- Primitive automated testing derived from and dependent upon approach in core repository.
- Mocked integration test in place using material from core repository.