### PR TITLE
expand-srv-config

### DIFF
--- a/pkg/dto/dto.go
+++ b/pkg/dto/dto.go
@@ -48,6 +48,8 @@ const (
 	PgSrvLogLevelKey                string = "pgsrv.loglevel"
 	PgSrvPortKey                    string = "pgsrv.port"
 	PgSrvRawTLSCfgKey               string = "pgsrv.tls"
+	PgSrvRawSrvCfgKey               string = "pgsrv.sundry"
+	PgSrvIsDebugNoticesEnabledKey   string = "pgsrv.debug.enable"
 	ProviderStrKey                  string = "provider"
 	QueryCacheSizeKey               string = "querycachesize"
 	RegistryRawKey                  string = "registry"

--- a/pkg/dto/runtime_ctx.go
+++ b/pkg/dto/runtime_ctx.go
@@ -37,6 +37,8 @@ type RuntimeCtx struct {
 	PGSrvLogLevel                string
 	PGSrvPort                    int
 	PGSrvRawTLSCfg               string
+	PGSrvRawSrvCfg               string
+	PGSrvIsDebugNoticesEnabled   bool
 	ExportAlias                  string
 	ProviderStr                  string
 	RegistryRaw                  string
@@ -173,6 +175,10 @@ func (rc *RuntimeCtx) Set(key string, val string) error {
 		retVal = setInt(&rc.PGSrvPort, val)
 	case PgSrvRawTLSCfgKey:
 		rc.PGSrvRawTLSCfg = val
+	case PgSrvRawSrvCfgKey:
+		rc.PGSrvRawSrvCfg = val
+	case PgSrvIsDebugNoticesEnabledKey:
+		retVal = setBool(&rc.PGSrvIsDebugNoticesEnabled, val)
 	case QueryCacheSizeKey:
 		retVal = setInt(&rc.QueryCacheSize, val)
 	case RegistryRawKey:
@@ -233,6 +239,8 @@ func (rc RuntimeCtx) Copy() RuntimeCtx {
 		PGSrvLogLevel:                rc.PGSrvLogLevel,
 		PGSrvPort:                    rc.PGSrvPort,
 		PGSrvRawTLSCfg:               rc.PGSrvRawTLSCfg,
+		PGSrvRawSrvCfg:               rc.PGSrvRawSrvCfg,
+		PGSrvIsDebugNoticesEnabled:   rc.PGSrvIsDebugNoticesEnabled,
 		ExportAlias:                  rc.ExportAlias,
 		ProviderStr:                  rc.ProviderStr,
 		RegistryRaw:                  rc.RegistryRaw,


### PR DESCRIPTION
## Summary

- Add extra server config fields.
- Supports expanded `postgres` server capabilities.