### PR TITLE
feat: add methods to remove existing provider version and clear provi…

### DIFF
--- a/anysdk/registry.go
+++ b/anysdk/registry.go
@@ -50,6 +50,8 @@ type RegistryAPI interface {
 	GetServiceDocBytes(string) ([]byte, error)
 	GetResourcesRegisterDocBytes(string) ([]byte, error)
 	LoadProviderByName(string, string) (Provider, error)
+	RemoveProviderVersion(string, string) error
+	ClearProviderCache(string) error
 }
 
 type RegistryConfig struct {
@@ -691,4 +693,18 @@ func (r *Registry) getLatestPublishedVersion(providerName string) (string, error
 		return "", err
 	}
 	return latestVersion, nil
+}
+
+// RemoveProviderVersion removes a specific version of a provider
+// e.g) RemoveProviderVersion("googleapis.com", "v23.09.00169")
+func (r *Registry) RemoveProviderVersion(providerId string, version string) error {
+	providerPath := path.Join(r.getLocalDocRoot(), providerId, version)
+	return os.RemoveAll(providerPath)
+}
+
+// ClearProviderCache clears the cache for a specific provider
+// e.g) ClearProviderCache("aws")
+func (r *Registry) ClearProviderCache(providerId string) error {
+	cachePath := path.Join(r.getLocalDocRoot(), providerId)
+	return os.RemoveAll(cachePath)
 }


### PR DESCRIPTION
This PR adds two helper methods to support behavior of `registry pull <provider> <version>` discussed in [stackql#470](https://github.com/stackql/stackql/issues/470#issuecomment-2907602799):

1. `RemoveProviderVersion(providerId, version)`  
   – Removes a version from the local registry directory.

2. `ClearProviderCache(providerId)`  
   – Clears all cached versions of a provider.

These utilities are designed to help implement the behavior where pulling a version should override a existing one.

While working on this issue, I found that the registry-related logic lives in the `any-sdk` repo, so this change is submitted here first.