### PR TITLE
policy-based-retry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -341,6 +341,33 @@ jobs:
         openssl req -x509 -keyout ${{ github.workspace }}/test/credentials/pg_client_key.pem  -out ${{ github.workspace }}/test/credentials/pg_client_cert.pem   -config ${{ github.workspace }}/stackql-core/test/server/mtls/openssl.cnf -days 365
         openssl req -x509 -keyout ${{ github.workspace }}/test/credentials/pg_rubbish_key.pem -out ${{ github.workspace }}/test/credentials/pg_rubbish_cert.pem  -config ${{ github.workspace }}/stackql-core/test/server/mtls/openssl.cnf -days 365
 
+    - name: Start Retry Mock
+      run: |
+        set -x
+        which flask || true
+        which python3 || true
+        flask --version || true
+        mkdir -p ${{ github.workspace }}/test/robot/cli/mocked/tmp
+        cd ${{ github.workspace }}
+        nohup flask --app=test/python/any_sdk_test_utils/mocks/retry_app:app run --host 127.0.0.1 --port 1199 \
+          > ${{ github.workspace }}/test/robot/cli/mocked/tmp/retry_mock_stdout.log \
+          2> ${{ github.workspace }}/test/robot/cli/mocked/tmp/retry_mock_stderr.log &
+        for i in $(seq 1 60); do
+          if curl -sf -X POST http://127.0.0.1:1199/reset > /dev/null; then
+            echo "Retry mock up after ${i} attempts"; break
+          fi
+          sleep 0.5
+        done
+        if ! curl -sf -X POST http://127.0.0.1:1199/reset; then
+          echo "===== Retry mock FAILED to start ====="
+          echo "----- stdout log -----"
+          cat ${{ github.workspace }}/test/robot/cli/mocked/tmp/retry_mock_stdout.log || true
+          echo "----- stderr log -----"
+          cat ${{ github.workspace }}/test/robot/cli/mocked/tmp/retry_mock_stderr.log || true
+          exit 1
+        fi
+        echo "Retry mock confirmed up on http://127.0.0.1:1199"
+
     - name: Run mocked robot tests
       env:
         AWS_ACCESS_KEY_ID: dummy
@@ -353,6 +380,14 @@ jobs:
       if: always()
       run: |
         cat test/robot/reports/mocked/output.xml
+
+    - name: upload mocked test results
+      if: always()
+      uses: actions/upload-artifact@v4.3.1
+      with:
+        name: mocked-robot-test-results
+        path: test/robot/reports/mocked
+
 
     - name: Run AOT CLI robot tests
       run: |

--- a/cicd/schema-definitions/resources-core.schema.json
+++ b/cicd/schema-definitions/resources-core.schema.json
@@ -88,6 +88,78 @@
       "additionalProperties": false
     },
 
+    "RetryConditions": {
+      "type": "object",
+      "description": "Per-response signals that mark a result as transient/retryable. Only HTTP status codes are checked today; the bag is open so future signals (header probes, body shape, error class) can be added without breaking specs.",
+      "properties": {
+        "status_codes": {
+          "type": "array",
+          "description": "HTTP status codes treated as transient. Defaults to [408, 429, 502, 503, 504] when omitted or empty.",
+          "items": { "type": "integer", "minimum": 100, "maximum": 599 }
+        }
+      },
+      "additionalProperties": true
+    },
+
+    "RetryPolicy": {
+      "type": "object",
+      "description": "Retry/backoff policy applied to outbound HTTP calls. Resolved with inheritance: operation -> resource -> service -> providerService -> provider; absent at every level falls back to defaults.",
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "description": "Backoff algorithm. Only 'exponential' is implemented today; unknown values degrade to a flat initial_delay_ms.",
+          "enum": ["exponential"],
+          "default": "exponential"
+        },
+        "max_attempts": {
+          "type": "integer",
+          "description": "Total attempts including the first try. Values < 1 fall back to the default (3). max_attempts: 1 disables retry.",
+          "minimum": 1,
+          "default": 3
+        },
+        "initial_delay_ms": {
+          "type": "integer",
+          "description": "Delay before the second attempt, in milliseconds. Values <= 0 fall back to the default (500ms).",
+          "minimum": 0,
+          "default": 500
+        },
+        "max_delay_ms": {
+          "type": "integer",
+          "description": "Per-attempt delay ceiling, in milliseconds. Values <= 0 fall back to the default (10000ms).",
+          "minimum": 0,
+          "default": 10000
+        },
+        "multiplier": {
+          "type": "number",
+          "description": "Exponential growth factor between attempts. Values <= 1 fall back to the default (2.0).",
+          "default": 2.0
+        },
+        "jitter_fraction": {
+          "type": "number",
+          "description": "Symmetric jitter band as a fraction of the computed delay (e.g. 0.2 -> +/-20%). Clamped to [0, 1]; 0 disables jitter.",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0
+        },
+        "retryable_methods": {
+          "type": "array",
+          "description": "HTTP methods eligible for retry. Use '*' to match every method. Defaults to ['GET', 'HEAD'] when omitted or empty.",
+          "items": { "type": "string" }
+        },
+        "retryable_conditions": { "$ref": "#/$defs/RetryConditions" }
+      },
+      "additionalProperties": false
+    },
+
+    "Config": {
+      "type": "object",
+      "description": "x-stackQL config bag. Recognised here only insofar as any-sdk consumes it; passthrough keys are tolerated.",
+      "properties": {
+        "retry": { "$ref": "#/$defs/RetryPolicy" }
+      },
+      "additionalProperties": true
+    },
+
     "Resource": {
       "type": "object",
       "required": ["id", "title", "methods"],
@@ -96,6 +168,7 @@
         "id":   { "$ref": "#/$defs/Name" },
         "name": { "$ref": "#/$defs/Name" },
         "title": { "type": "string" },
+        "config": { "$ref": "#/$defs/Config" },
         "methods": { "$ref": "#/$defs/MethodsMap" },
         "sqlVerbs": { "$ref": "#/$defs/SqlVerbs" }
       },

--- a/cicd/testing-requirements.txt
+++ b/cicd/testing-requirements.txt
@@ -1,3 +1,4 @@
+flask==3.1.3
 PyYaml==6.0.2
 requests==2.32.3
 robotframework==7.0.1

--- a/docs/retry_policy.md
+++ b/docs/retry_policy.md
@@ -1,0 +1,133 @@
+# Retry Policy
+
+`any-sdk` retries transient HTTP failures with configurable backoff. Policies
+are declared in spec YAML and resolved per request, so the same provider can
+mix lenient and strict retry behaviour across resources without code changes.
+
+## Where to declare
+
+A `retry` block lives under a `config` (or `x-stackQL-config`) object at any
+of five levels. The first level that declares one wins; nothing inherits
+piecewise from a parent.
+
+| Level | YAML location |
+|---|---|
+| Operation | `paths.<path>.<verb>.x-stackQL-config.retry` |
+| Resource | `components.x-stackQL-resources.<name>.config.retry` |
+| Service | top-level `x-stackQL-config.retry` of the service spec |
+| Provider service | `providerServices.<name>.x-stackQL-config.retry` |
+| Provider | `x-stackQL-config.retry` on the provider doc |
+
+Resolution order is operation -> resource -> service -> providerService ->
+provider, then a built-in default if nothing is declared.
+
+## Example
+
+```yaml
+components:
+  x-stackQL-resources:
+    recoverable_configured:
+      id: retrytestprovider.flaky.recoverable_configured
+      name: recoverable_configured
+      title: Recoverable using configured 5-attempt policy
+      config:
+        retry:
+          algorithm: exponential
+          max_attempts: 5
+          initial_delay_ms: 5
+          max_delay_ms: 25
+          multiplier: 2
+          jitter_fraction: 0.1
+          retryable_methods:
+            - GET
+          retryable_conditions:
+            status_codes:
+              - 503
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1flaky~1configured-recover/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+```
+
+## Fields
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `algorithm` | string | `exponential` | Only `exponential` is implemented; unknown values fall back to a flat `initial_delay_ms`. |
+| `max_attempts` | integer | `3` | Total attempts including the first try. `1` disables retry. Values `< 1` snap to the default. |
+| `initial_delay_ms` | integer | `500` | Delay before the second attempt. Values `<= 0` snap to the default. |
+| `max_delay_ms` | integer | `10000` | Per-attempt ceiling after exponential growth. Values `<= 0` snap to the default. |
+| `multiplier` | number | `2.0` | Exponential growth factor. Values `<= 1` snap to the default. |
+| `jitter_fraction` | number | `0` | Symmetric jitter band as a fraction of the computed delay (e.g. `0.2` = +/-20%). Clamped to `[0, 1]`. |
+| `retryable_methods` | string[] | `["GET", "HEAD"]` | Methods eligible for retry. Use `"*"` to match every method. |
+| `retryable_conditions.status_codes` | integer[] | `[408, 429, 502, 503, 504]` | HTTP statuses treated as transient. |
+
+A request whose method is not in `retryable_methods` always makes exactly one
+attempt regardless of `max_attempts`.
+
+## Backoff calculation
+
+For attempt _n_ (1-indexed, where _n_=1 is the wait before the second try):
+
+```
+delay = min(initial_delay_ms * multiplier^(n-1), max_delay_ms)
+if jitter_fraction > 0:
+    delay *= 1 + uniform(-jitter_fraction, +jitter_fraction)
+    delay = clamp(delay, 0, max_delay_ms)
+```
+
+`max_delay_ms` caps both the pre-jitter exponential and the post-jitter
+result, so jitter cannot push a wait past the ceiling.
+
+## Request body handling
+
+When `max_attempts > 1` and the request has a body, `any-sdk` reads it into
+memory once and rebuilds `req.Body` (and `req.GetBody`) from the buffered
+bytes for each attempt. This means:
+
+- The body is consumed only once from the caller's reader.
+- Streaming bodies of unknown size are buffered in full before the first
+  attempt.
+- The same bytes are replayed on every retry; transformations applied between
+  the caller and `any-sdk` (translate, body rewrite) run before buffering and
+  are not re-evaluated per attempt.
+
+## Cancellation
+
+Each backoff wait runs against `req.Context()`. If the context is cancelled
+during a wait, the loop exits and returns the last response/error.
+
+## Defaults
+
+Omitting the `retry` block entirely (or declaring it nowhere in the chain)
+yields the policy returned by `DefaultRetryPolicy()`:
+
+- `algorithm: exponential`
+- `max_attempts: 3`
+- `initial_delay_ms: 500`
+- `max_delay_ms: 10000`
+- `multiplier: 2.0`
+- `jitter_fraction: 0`
+- `retryable_methods: [GET, HEAD]`
+- `retryable_conditions.status_codes: [408, 429, 502, 503, 504]`
+
+## Schema
+
+The JSON Schema for the `retry` block lives in
+[`cicd/schema-definitions/resources-core.schema.json`](../cicd/schema-definitions/resources-core.schema.json)
+under `$defs/RetryPolicy` and `$defs/RetryConditions`.
+
+## Tests
+
+End-to-end behaviour is exercised by the Robot suite in
+[`test/robot/cli/mocked/adhoc.robot`](../test/robot/cli/mocked/adhoc.robot)
+against the Flask retry mock at
+[`test/python/any_sdk_test_utils/mocks/retry_app.py`](../test/python/any_sdk_test_utils/mocks/retry_app.py).
+The fixture provider lives at
+[`test/registry-mocked/src/retrytestprovider/v0.1.0/`](../test/registry-mocked/src/retrytestprovider/v0.1.0/)
+and covers four scenarios: default policy recovers after transient 503s, a
+configured 5-attempt policy recovers on the fifth try, a 1-attempt policy
+issues exactly one request, and a tight retry budget surfaces the final 503.

--- a/internal/anysdk/client.go
+++ b/internal/anysdk/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/stackql/any-sdk/pkg/auth_util"
 	"github.com/stackql/any-sdk/pkg/client"
@@ -127,12 +128,104 @@ func (hc *anySdkHttpClient) Do(designation client.AnySdkDesignation, argList cli
 	if translationErr != nil {
 		return nil, translationErr
 	}
-	httpResponse, httpResponseErr := hc.client.Do(translatedRequest)
+	policy := resolveRetryPolicy(designation)
+	httpResponse, httpResponseErr := hc.doWithRetry(translatedRequest, policy)
 	if httpResponseErr != nil {
 		return nil, httpResponseErr
 	}
 	anySdkHttpResponse := newAnySdkHttpReponse(httpResponse)
 	return anySdkHttpResponse, nil
+}
+
+// resolveRetryPolicy walks the designation back to its OperationStore (when
+// present) and consults the inheritance chain. Falls back to defaults when the
+// designation does not carry an OperationStore (e.g. monitor pings, GraphQL).
+func resolveRetryPolicy(designation client.AnySdkDesignation) RetryPolicy {
+	if designation == nil {
+		return DefaultRetryPolicy()
+	}
+	raw, ok := designation.GetDesignation()
+	if !ok {
+		return DefaultRetryPolicy()
+	}
+	if op, isOp := raw.(OperationStore); isOp {
+		return op.GetRetryPolicy()
+	}
+	return DefaultRetryPolicy()
+}
+
+// doWithRetry buffers the request body once, then runs up to MaxAttempts tries
+// with backoff between them. Only requests whose method is in the policy's
+// retryable-methods set get retried; everything else makes a single attempt.
+// Network errors and policy-listed status codes are treated as retryable.
+func (hc *anySdkHttpClient) doWithRetry(req *http.Request, policy RetryPolicy) (*http.Response, error) {
+	if policy == nil {
+		policy = DefaultRetryPolicy()
+	}
+	maxAttempts := policy.GetMaxAttempts()
+	methodRetryable := policy.IsMethodRetryable(req.Method)
+	if !methodRetryable {
+		maxAttempts = 1
+	}
+
+	var bodyBytes []byte
+	if req.Body != nil && maxAttempts > 1 {
+		buf, readErr := io.ReadAll(req.Body)
+		_ = req.Body.Close()
+		if readErr != nil {
+			return nil, readErr
+		}
+		bodyBytes = buf
+		req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+		if req.GetBody == nil {
+			req.GetBody = func() (io.ReadCloser, error) {
+				return io.NopCloser(bytes.NewReader(bodyBytes)), nil
+			}
+		}
+	}
+
+	var lastResp *http.Response
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if attempt > 1 {
+			if bodyBytes != nil {
+				req.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+			}
+			delay := policy.BackoffFor(attempt - 1)
+			ctx := req.Context()
+			if delay > 0 {
+				timer := time.NewTimer(delay)
+				select {
+				case <-ctx.Done():
+					timer.Stop()
+					if lastErr == nil {
+						lastErr = ctx.Err()
+					}
+					return lastResp, lastErr
+				case <-timer.C:
+				}
+			}
+		}
+		resp, err := hc.client.Do(req)
+		lastResp = resp
+		lastErr = err
+		if err != nil {
+			if attempt < maxAttempts {
+				continue
+			}
+			return nil, err
+		}
+		if attempt < maxAttempts && policy.IsStatusRetryable(resp.StatusCode) {
+			// drain & close so the connection can be reused
+			if resp.Body != nil {
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+			continue
+		}
+		return resp, nil
+	}
+	return lastResp, lastErr
 }
 
 type anySdkHTTPClientConfigurator struct {

--- a/internal/anysdk/config.go
+++ b/internal/anysdk/config.go
@@ -23,6 +23,7 @@ type StackQLConfig interface {
 	GetViews() map[string]View
 	GetExternalTables() map[string]SQLExternalTable
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
+	GetRetryPolicy() (RetryPolicy, bool)
 	GetMinStackQLVersion() string
 	//
 	isObjectSchemaImplicitlyUnioned() bool
@@ -40,6 +41,7 @@ type standardStackQLConfig struct {
 	ExternalTables       map[string]standardSQLExternalTable `json:"sqlExternalTables" yaml:"sqlExternalTables"`
 	Auth                 *standardAuthDTO                    `json:"auth,omitempty" yaml:"auth,omitempty"`
 	QueryParamPushdown   *standardQueryParamPushdown         `json:"queryParamPushdown,omitempty" yaml:"queryParamPushdown,omitempty"`
+	Retry                *standardRetryPolicy                `json:"retry,omitempty" yaml:"retry,omitempty"`
 	MinStackQLVersion    string                              `json:"minStackQLVersion,omitempty" yaml:"minStackQLVersion,omitempty"`
 }
 
@@ -55,6 +57,8 @@ func (qt standardStackQLConfig) JSONLookup(token string) (interface{}, error) {
 		return qt.Views, nil
 	case "queryParamPushdown":
 		return qt.QueryParamPushdown, nil
+	case "retry":
+		return qt.Retry, nil
 	case "minStackQLVersion":
 		return qt.MinStackQLVersion, nil
 	default:
@@ -144,6 +148,13 @@ func (cfg *standardStackQLConfig) GetQueryParamPushdown() (QueryParamPushdown, b
 		return nil, false
 	}
 	return cfg.QueryParamPushdown, true
+}
+
+func (cfg *standardStackQLConfig) GetRetryPolicy() (RetryPolicy, bool) {
+	if cfg.Retry == nil {
+		return nil, false
+	}
+	return cfg.Retry, true
 }
 
 func (cfg *standardStackQLConfig) GetExternalTables() map[string]SQLExternalTable {

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -64,6 +64,7 @@ type OperationStore interface {
 	GetInverse() (OperationInverse, bool)
 	GetStackQLConfig() StackQLConfig
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
+	GetRetryPolicy() RetryPolicy
 	GetParameters() map[string]Addressable
 	GetPathItem() *openapi3.PathItem
 	GetAPIMethod() string
@@ -405,6 +406,38 @@ func (op *standardOpenAPIOperationStore) GetStackQLConfig() StackQLConfig {
 func (op *standardOpenAPIOperationStore) getStackQLConfig() (StackQLConfig, bool) {
 	rv := op.StackQLConfig
 	return rv, rv != nil
+}
+
+// GetRetryPolicy returns the retry policy with the same inheritance walk used
+// for queryParamPushdown: Method -> Resource -> Service -> ProviderService -> Provider.
+// Falls back to DefaultRetryPolicy() so callers always get a usable policy.
+func (op *standardOpenAPIOperationStore) GetRetryPolicy() RetryPolicy {
+	if op.StackQLConfig != nil {
+		if rp, ok := op.StackQLConfig.GetRetryPolicy(); ok {
+			return rp
+		}
+	}
+	if op.Resource != nil {
+		if rp, ok := op.Resource.GetRetryPolicy(); ok {
+			return rp
+		}
+	}
+	if op.OpenAPIService != nil {
+		if rp, ok := op.OpenAPIService.getRetryPolicy(); ok {
+			return rp
+		}
+	}
+	if op.ProviderService != nil {
+		if rp, ok := op.ProviderService.GetRetryPolicy(); ok {
+			return rp
+		}
+	}
+	if op.Provider != nil {
+		if rp, ok := op.Provider.GetRetryPolicy(); ok {
+			return rp
+		}
+	}
+	return DefaultRetryPolicy()
 }
 
 // GetQueryParamPushdown returns the queryParamPushdown config with inheritance.

--- a/internal/anysdk/provider.go
+++ b/internal/anysdk/provider.go
@@ -31,6 +31,7 @@ type Provider interface {
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
+	GetRetryPolicy() (RetryPolicy, bool)
 	GetProviderService(key string) (ProviderService, error)
 	getQueryTransposeAlgorithm() string
 	GetRequestTranslateAlgorithm() string
@@ -141,6 +142,13 @@ func (pr *standardProvider) GetPaginationResponseTokenSemantic() (TokenSemantic,
 func (pr *standardProvider) GetQueryParamPushdown() (QueryParamPushdown, bool) {
 	if pr.StackQLConfig != nil {
 		return pr.StackQLConfig.GetQueryParamPushdown()
+	}
+	return nil, false
+}
+
+func (pr *standardProvider) GetRetryPolicy() (RetryPolicy, bool) {
+	if pr.StackQLConfig != nil {
+		return pr.StackQLConfig.GetRetryPolicy()
 	}
 	return nil, false
 }

--- a/internal/anysdk/providerService.go
+++ b/internal/anysdk/providerService.go
@@ -26,6 +26,7 @@ type ProviderService interface {
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	getPaginationResponseTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
+	GetRetryPolicy() (RetryPolicy, bool)
 	ConditionIsValid(lhs string, rhs interface{}) bool
 	GetID() string
 	GetServiceFragment(resourceKey string) (Service, error)
@@ -182,6 +183,13 @@ func (sv *standardProviderService) getPaginationResponseTokenSemantic() (TokenSe
 func (sv *standardProviderService) GetQueryParamPushdown() (QueryParamPushdown, bool) {
 	if sv.StackQLConfig != nil {
 		return sv.StackQLConfig.GetQueryParamPushdown()
+	}
+	return nil, false
+}
+
+func (sv *standardProviderService) GetRetryPolicy() (RetryPolicy, bool) {
+	if sv.StackQLConfig != nil {
+		return sv.StackQLConfig.GetRetryPolicy()
 	}
 	return nil, false
 }

--- a/internal/anysdk/resource.go
+++ b/internal/anysdk/resource.go
@@ -28,6 +28,7 @@ type Resource interface {
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
+	GetRetryPolicy() (RetryPolicy, bool)
 	FindMethod(key string) (StandardOperationStore, error)
 	GetFirstMethodFromSQLVerb(sqlVerb string) (StandardOperationStore, string, bool)
 	GetFirstNamespaceMethodMatchFromSQLVerb(sqlVerb string, parameters map[string]interface{}) (StandardOperationStore, map[string]interface{}, bool)
@@ -205,6 +206,13 @@ func (r *standardResource) GetPaginationResponseTokenSemantic() (TokenSemantic, 
 func (r *standardResource) GetQueryParamPushdown() (QueryParamPushdown, bool) {
 	if r.StackQLConfig != nil {
 		return r.StackQLConfig.GetQueryParamPushdown()
+	}
+	return nil, false
+}
+
+func (r *standardResource) GetRetryPolicy() (RetryPolicy, bool) {
+	if r.StackQLConfig != nil {
+		return r.StackQLConfig.GetRetryPolicy()
 	}
 	return nil, false
 }

--- a/internal/anysdk/retry.go
+++ b/internal/anysdk/retry.go
@@ -1,0 +1,260 @@
+package anysdk
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+
+	"github.com/go-openapi/jsonpointer"
+)
+
+const (
+	RetryAlgorithmExponential = "exponential"
+
+	defaultRetryAlgorithm      = RetryAlgorithmExponential
+	defaultRetryMaxAttempts    = 3
+	defaultRetryInitialDelayMs = 500
+	defaultRetryMaxDelayMs     = 10000
+	defaultRetryMultiplier     = 2.0
+	defaultRetryJitterFraction = 0.0
+)
+
+var (
+	_ RetryPolicy               = &standardRetryPolicy{}
+	_ RetryConditions           = &standardRetryConditions{}
+	_ jsonpointer.JSONPointable = standardRetryPolicy{}
+	_ jsonpointer.JSONPointable = standardRetryConditions{}
+
+	defaultRetryableStatusCodes = []int{
+		http.StatusRequestTimeout,
+		http.StatusTooManyRequests,
+		http.StatusBadGateway,
+		http.StatusServiceUnavailable,
+		http.StatusGatewayTimeout,
+	}
+
+	defaultRetryableMethods = []string{
+		http.MethodGet,
+		http.MethodHead,
+	}
+)
+
+// RetryPolicy describes how a remote call should be retried on transient
+// failure. Algorithm is a string so we can introduce alternative strategies
+// without breaking existing specs; the only currently supported value is
+// "exponential".
+type RetryPolicy interface {
+	GetAlgorithm() string
+	GetMaxAttempts() int
+	GetInitialDelay() time.Duration
+	GetMaxDelay() time.Duration
+	GetMultiplier() float64
+	GetJitterFraction() float64
+	GetRetryableConditions() RetryConditions
+	GetRetryableMethods() []string
+	IsStatusRetryable(statusCode int) bool
+	IsMethodRetryable(method string) bool
+	BackoffFor(attempt int) time.Duration
+}
+
+// RetryConditions enumerates the per-response signals that mark a result as
+// retryable. Currently only HTTP status codes are checked, but the type is
+// modelled as an extensible bag so future signals (header probes, body shape,
+// error class) can be added without rewriting specs.
+type RetryConditions interface {
+	GetStatusCodes() []int
+	IsStatusRetryable(statusCode int) bool
+}
+
+type standardRetryConditions struct {
+	StatusCodes []int `json:"status_codes,omitempty" yaml:"status_codes,omitempty"`
+}
+
+func (rc standardRetryConditions) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "status_codes":
+		return rc.StatusCodes, nil
+	default:
+		return nil, fmt.Errorf("could not resolve token '%s' from RetryConditions doc object", token)
+	}
+}
+
+func (rc *standardRetryConditions) GetStatusCodes() []int {
+	if len(rc.StatusCodes) == 0 {
+		out := make([]int, len(defaultRetryableStatusCodes))
+		copy(out, defaultRetryableStatusCodes)
+		return out
+	}
+	return rc.StatusCodes
+}
+
+func (rc *standardRetryConditions) IsStatusRetryable(statusCode int) bool {
+	for _, c := range rc.GetStatusCodes() {
+		if c == statusCode {
+			return true
+		}
+	}
+	return false
+}
+
+type standardRetryPolicy struct {
+	Algorithm           string                   `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	MaxAttempts         int                      `json:"max_attempts,omitempty" yaml:"max_attempts,omitempty"`
+	InitialDelayMs      int                      `json:"initial_delay_ms,omitempty" yaml:"initial_delay_ms,omitempty"`
+	MaxDelayMs          int                      `json:"max_delay_ms,omitempty" yaml:"max_delay_ms,omitempty"`
+	Multiplier          float64                  `json:"multiplier,omitempty" yaml:"multiplier,omitempty"`
+	JitterFraction      float64                  `json:"jitter_fraction,omitempty" yaml:"jitter_fraction,omitempty"`
+	RetryableConditions *standardRetryConditions `json:"retryable_conditions,omitempty" yaml:"retryable_conditions,omitempty"`
+	RetryableMethods    []string                 `json:"retryable_methods,omitempty" yaml:"retryable_methods,omitempty"`
+}
+
+func (rp standardRetryPolicy) JSONLookup(token string) (interface{}, error) {
+	switch token {
+	case "algorithm":
+		return rp.Algorithm, nil
+	case "max_attempts":
+		return rp.MaxAttempts, nil
+	case "initial_delay_ms":
+		return rp.InitialDelayMs, nil
+	case "max_delay_ms":
+		return rp.MaxDelayMs, nil
+	case "multiplier":
+		return rp.Multiplier, nil
+	case "jitter_fraction":
+		return rp.JitterFraction, nil
+	case "retryable_conditions":
+		return rp.RetryableConditions, nil
+	case "retryable_methods":
+		return rp.RetryableMethods, nil
+	default:
+		return nil, fmt.Errorf("could not resolve token '%s' from RetryPolicy doc object", token)
+	}
+}
+
+func (rp *standardRetryPolicy) GetAlgorithm() string {
+	if rp.Algorithm == "" {
+		return defaultRetryAlgorithm
+	}
+	return rp.Algorithm
+}
+
+func (rp *standardRetryPolicy) GetMaxAttempts() int {
+	if rp.MaxAttempts < 1 {
+		return defaultRetryMaxAttempts
+	}
+	return rp.MaxAttempts
+}
+
+func (rp *standardRetryPolicy) GetInitialDelay() time.Duration {
+	if rp.InitialDelayMs <= 0 {
+		return time.Duration(defaultRetryInitialDelayMs) * time.Millisecond
+	}
+	return time.Duration(rp.InitialDelayMs) * time.Millisecond
+}
+
+func (rp *standardRetryPolicy) GetMaxDelay() time.Duration {
+	if rp.MaxDelayMs <= 0 {
+		return time.Duration(defaultRetryMaxDelayMs) * time.Millisecond
+	}
+	return time.Duration(rp.MaxDelayMs) * time.Millisecond
+}
+
+func (rp *standardRetryPolicy) GetMultiplier() float64 {
+	if rp.Multiplier <= 1 {
+		return defaultRetryMultiplier
+	}
+	return rp.Multiplier
+}
+
+func (rp *standardRetryPolicy) GetJitterFraction() float64 {
+	if rp.JitterFraction < 0 {
+		return 0
+	}
+	if rp.JitterFraction > 1 {
+		return 1
+	}
+	if rp.JitterFraction == 0 {
+		return defaultRetryJitterFraction
+	}
+	return rp.JitterFraction
+}
+
+func (rp *standardRetryPolicy) GetRetryableConditions() RetryConditions {
+	if rp.RetryableConditions == nil {
+		return &standardRetryConditions{}
+	}
+	return rp.RetryableConditions
+}
+
+func (rp *standardRetryPolicy) GetRetryableMethods() []string {
+	if len(rp.RetryableMethods) == 0 {
+		out := make([]string, len(defaultRetryableMethods))
+		copy(out, defaultRetryableMethods)
+		return out
+	}
+	return rp.RetryableMethods
+}
+
+func (rp *standardRetryPolicy) IsStatusRetryable(statusCode int) bool {
+	return rp.GetRetryableConditions().IsStatusRetryable(statusCode)
+}
+
+func (rp *standardRetryPolicy) IsMethodRetryable(method string) bool {
+	for _, m := range rp.GetRetryableMethods() {
+		if m == "*" {
+			return true
+		}
+		if m == method {
+			return true
+		}
+	}
+	return false
+}
+
+// BackoffFor returns the delay to wait before the given attempt number
+// (1-indexed). attempt==1 means "wait before the second try", etc.
+func (rp *standardRetryPolicy) BackoffFor(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	algo := rp.GetAlgorithm()
+	initial := rp.GetInitialDelay()
+	maxDelay := rp.GetMaxDelay()
+	var d time.Duration
+	switch algo {
+	case RetryAlgorithmExponential:
+		multiplier := rp.GetMultiplier()
+		factor := math.Pow(multiplier, float64(attempt-1))
+		nanos := float64(initial) * factor
+		if math.IsInf(nanos, 0) || nanos > float64(maxDelay) {
+			d = maxDelay
+		} else {
+			d = time.Duration(nanos)
+		}
+	default:
+		d = initial
+	}
+	if d > maxDelay {
+		d = maxDelay
+	}
+	jf := rp.GetJitterFraction()
+	if jf > 0 {
+		noise := (rand.Float64()*2 - 1) * jf //nolint:gosec // not security-sensitive
+		d = time.Duration(float64(d) * (1 + noise))
+		if d < 0 {
+			d = 0
+		}
+		if d > maxDelay {
+			d = maxDelay
+		}
+	}
+	return d
+}
+
+// DefaultRetryPolicy returns the policy applied when no x-stackQL-config
+// retry block is present anywhere in the inheritance chain.
+func DefaultRetryPolicy() RetryPolicy {
+	return &standardRetryPolicy{}
+}

--- a/internal/anysdk/retry_test.go
+++ b/internal/anysdk/retry_test.go
@@ -1,0 +1,300 @@
+package anysdk
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stackql/any-sdk/pkg/client"
+)
+
+// We test the HTTP retry path end-to-end against an in-process httptest.Server.
+// This deliberately avoids depending on the broader stackql/flask mock corpus
+// (which lives in the stackql repo) so the test stays self-contained here.
+//
+// Tests drive doWithRetry directly to dodge the need to stub the very wide
+// OperationStore interface; the resolveRetryPolicy path is covered separately.
+
+// scriptedHandler returns the next status code from `script` for each request.
+// When the script is exhausted it keeps returning the final entry. It also
+// records how many requests it received and the bodies it observed.
+type scriptedHandler struct {
+	script        []int
+	calls         int64
+	receivedBodies []string
+}
+
+func (h *scriptedHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	idx := atomic.AddInt64(&h.calls, 1) - 1
+	body, _ := io.ReadAll(r.Body)
+	_ = r.Body.Close()
+	h.receivedBodies = append(h.receivedBodies, string(body))
+	status := h.script[len(h.script)-1]
+	if int(idx) < len(h.script) {
+		status = h.script[idx]
+	}
+	w.WriteHeader(status)
+	fmt.Fprintf(w, "attempt %d -> %d", idx+1, status)
+}
+
+func newScriptedServer(t *testing.T, script ...int) (*httptest.Server, *scriptedHandler) {
+	t.Helper()
+	h := &scriptedHandler{script: script}
+	srv := httptest.NewServer(h)
+	t.Cleanup(srv.Close)
+	return srv, h
+}
+
+func newTestHttpClient() *anySdkHttpClient {
+	return &anySdkHttpClient{client: http.DefaultClient}
+}
+
+// fastPolicy returns a policy whose backoff is sub-millisecond so tests stay
+// fast. It still exercises the real exponential math.
+func fastPolicy(maxAttempts int, methods []string, statusCodes []int) RetryPolicy {
+	return &standardRetryPolicy{
+		Algorithm:        RetryAlgorithmExponential,
+		MaxAttempts:      maxAttempts,
+		InitialDelayMs:   1,
+		MaxDelayMs:       5,
+		Multiplier:       2,
+		RetryableMethods: methods,
+		RetryableConditions: &standardRetryConditions{
+			StatusCodes: statusCodes,
+		},
+	}
+}
+
+func mustReq(t *testing.T, method, url string, body string) *http.Request {
+	t.Helper()
+	var br io.Reader
+	if body != "" {
+		br = strings.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(context.Background(), method, url, br)
+	if err != nil {
+		t.Fatalf("could not build request: %v", err)
+	}
+	return req
+}
+
+// --- max_attempts == 1 means the policy is opted out of retrying ----------
+
+func TestRetry_ZeroRepeats_OnlyOneAttempt(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusServiceUnavailable, http.StatusOK)
+	hc := newTestHttpClient()
+	policy := fastPolicy(1, []string{"*"}, []int{http.StatusServiceUnavailable})
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodGet, srv.URL, ""), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 (no retry), got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 1 {
+		t.Fatalf("expected exactly 1 server call, got %d", got)
+	}
+}
+
+// --- default policy: 3 attempts, retry on 503, GET only -------------------
+
+func TestRetry_Default_RecoversWithinBudget(t *testing.T) {
+	srv, h := newScriptedServer(t,
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusOK,
+	)
+	hc := newTestHttpClient()
+	// Use the bare default policy — exercises the real fallback path.
+	// Override the delay to keep the test fast without changing semantics.
+	policy := &standardRetryPolicy{InitialDelayMs: 1, MaxDelayMs: 2}
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodGet, srv.URL, ""), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 3 {
+		t.Fatalf("expected 3 server calls (2 retried + 1 success), got %d", got)
+	}
+}
+
+func TestRetry_Default_ExhaustsAttemptsAndReturnsLastResponse(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusServiceUnavailable)
+	hc := newTestHttpClient()
+	policy := &standardRetryPolicy{InitialDelayMs: 1, MaxDelayMs: 2}
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodGet, srv.URL, ""), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503 after exhaustion, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != int64(defaultRetryMaxAttempts) {
+		t.Fatalf("expected %d server calls, got %d", defaultRetryMaxAttempts, got)
+	}
+}
+
+func TestRetry_Default_DoesNotRetryNonRetryableStatus(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusBadRequest)
+	hc := newTestHttpClient()
+	policy := &standardRetryPolicy{InitialDelayMs: 1, MaxDelayMs: 2}
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodGet, srv.URL, ""), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 1 {
+		t.Fatalf("expected 1 server call (400 is not retryable by default), got %d", got)
+	}
+}
+
+func TestRetry_Default_DoesNotRetryNonRetryableMethod(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusServiceUnavailable)
+	hc := newTestHttpClient()
+	policy := &standardRetryPolicy{InitialDelayMs: 1, MaxDelayMs: 2}
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodPost, srv.URL, "{}"), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 1 {
+		t.Fatalf("expected 1 server call (POST is not retryable by default), got %d", got)
+	}
+}
+
+// --- caller-configured policy ---------------------------------------------
+
+func TestRetry_Configured_FiveAttempts_SucceedsOnFifth(t *testing.T) {
+	srv, h := newScriptedServer(t,
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusServiceUnavailable,
+		http.StatusOK,
+	)
+	hc := newTestHttpClient()
+	policy := fastPolicy(5, []string{http.MethodGet}, []int{http.StatusServiceUnavailable})
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodGet, srv.URL, ""), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 on fifth attempt, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 5 {
+		t.Fatalf("expected 5 server calls, got %d", got)
+	}
+}
+
+func TestRetry_Configured_WildcardMethodAndCustomStatus(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusConflict, http.StatusOK)
+	hc := newTestHttpClient()
+	policy := fastPolicy(3, []string{"*"}, []int{http.StatusConflict})
+
+	resp, err := hc.doWithRetry(mustReq(t, http.MethodPost, srv.URL, `{"k":"v"}`), policy)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 after retry on 409, got %d", resp.StatusCode)
+	}
+	if got := atomic.LoadInt64(&h.calls); got != 2 {
+		t.Fatalf("expected 2 server calls, got %d", got)
+	}
+	// Body should have been replayed exactly on retry.
+	for i, b := range h.receivedBodies {
+		if b != `{"k":"v"}` {
+			t.Fatalf("attempt %d received body %q; expected body to be replayed verbatim", i+1, b)
+		}
+	}
+}
+
+// --- network-level transient failure --------------------------------------
+
+func TestRetry_RetriesOnTransportError(t *testing.T) {
+	// Stand a server up, snag its URL, then close it so the next dial fails.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	url := srv.URL
+	srv.Close()
+
+	hc := newTestHttpClient()
+	policy := fastPolicy(3, []string{http.MethodGet}, nil)
+
+	_, err := hc.doWithRetry(mustReq(t, http.MethodGet, url, ""), policy)
+	if err == nil {
+		t.Fatalf("expected dial error after exhausting retries")
+	}
+}
+
+// --- context cancellation interrupts backoff ------------------------------
+
+func TestRetry_ContextCancellationStopsBackoff(t *testing.T) {
+	srv, h := newScriptedServer(t, http.StatusServiceUnavailable)
+	hc := newTestHttpClient()
+	policy := &standardRetryPolicy{
+		MaxAttempts:    3,
+		InitialDelayMs: 200,
+		MaxDelayMs:     200,
+		Multiplier:     1.0001,
+		RetryableMethods: []string{http.MethodGet},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	req := mustReq(t, http.MethodGet, srv.URL, "").WithContext(ctx)
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, _ = hc.doWithRetry(req, policy)
+	// First attempt always runs; backoff before attempt 2 should be cut
+	// short by ctx cancellation, so we should never see attempt 3.
+	if got := atomic.LoadInt64(&h.calls); got > 2 {
+		t.Fatalf("expected at most 2 server calls before cancellation, got %d", got)
+	}
+}
+
+// --- resolveRetryPolicy fallback ------------------------------------------
+
+type retrylessDesignation struct{}
+
+func (retrylessDesignation) GetDesignation() (interface{}, bool) { return "not-an-op-store", true }
+
+func TestResolveRetryPolicy_FallsBackToDefaultsWhenNoOperationStore(t *testing.T) {
+	policy := resolveRetryPolicy(nil)
+	if policy == nil {
+		t.Fatalf("expected non-nil policy from nil designation")
+	}
+	if policy.GetMaxAttempts() != defaultRetryMaxAttempts {
+		t.Fatalf("expected default max attempts %d, got %d", defaultRetryMaxAttempts, policy.GetMaxAttempts())
+	}
+
+	var d client.AnySdkDesignation = retrylessDesignation{}
+	policy = resolveRetryPolicy(d)
+	if policy == nil {
+		t.Fatalf("expected non-nil policy when designation has no op store")
+	}
+	if policy.GetAlgorithm() != RetryAlgorithmExponential {
+		t.Fatalf("expected default exponential algorithm, got %q", policy.GetAlgorithm())
+	}
+}

--- a/internal/anysdk/service.go
+++ b/internal/anysdk/service.go
@@ -36,6 +36,7 @@ type OpenAPIService interface {
 	getPaginationResponseTokenSemantic() (TokenSemantic, bool)
 	getQueryTransposeAlgorithm() string
 	getQueryParamPushdown() (QueryParamPushdown, bool)
+	getRetryPolicy() (RetryPolicy, bool)
 	GetT() *openapi3.T
 	getT() *openapi3.T
 	iDiscoveryDoc()
@@ -286,6 +287,13 @@ func (svc *standardService) getPaginationResponseTokenSemantic() (TokenSemantic,
 func (svc *standardService) getQueryParamPushdown() (QueryParamPushdown, bool) {
 	if svc.StackQLConfig != nil {
 		return svc.StackQLConfig.GetQueryParamPushdown()
+	}
+	return nil, false
+}
+
+func (svc *standardService) getRetryPolicy() (RetryPolicy, bool) {
+	if svc.StackQLConfig != nil {
+		return svc.StackQLConfig.GetRetryPolicy()
 	}
 	return nil, false
 }

--- a/test/python/any_sdk_test_utils/mocks/retry_app.py
+++ b/test/python/any_sdk_test_utils/mocks/retry_app.py
@@ -1,0 +1,71 @@
+"""Local fragment of the upstream stackql flask mock pattern.
+
+Mirrors the layout used by stackql/test/python/stackql_test_tooling/flask/<svc>/app.py
+but lives in this repo so the retry CLI tests are fully self-contained — no
+checkout of the stackql core repo or its test tooling is required.
+
+Run with:
+    flask --app=test/python/any_sdk_test_utils/mocks/retry_app:app run --host 127.0.0.1 --port 1199
+"""
+
+from collections import defaultdict
+from threading import Lock
+
+from flask import Flask, jsonify, request
+
+
+def create_app() -> Flask:
+    app = Flask(__name__)
+
+    counters: "defaultdict[str, int]" = defaultdict(int)
+    lock = Lock()
+
+    @app.post("/reset")
+    def reset():
+        with lock:
+            counters.clear()
+        return jsonify({"ok": True})
+
+    @app.get("/count/<key>")
+    def count(key: str):
+        with lock:
+            return jsonify({"key": key, "attempts": counters[key]})
+
+    @app.get("/flaky/<key>")
+    def flaky(key: str):
+        # Returns 503 for the first `fail_until` calls keyed by `key`, then 200.
+        # The response body always reports the current attempt number so robot
+        # tests can verify retry counts directly from CLI stdout.
+        try:
+            fail_until = int(request.args.get("fail_until", "0"))
+        except ValueError:
+            fail_until = 0
+        with lock:
+            counters[key] += 1
+            attempt = counters[key]
+        body = {"key": key, "attempt": attempt, "fail_until": fail_until}
+        if attempt <= fail_until:
+            return jsonify({**body, "ok": False}), 503
+        return jsonify({**body, "ok": True})
+
+    @app.get("/always_503")
+    def always_503():
+        with lock:
+            counters["always_503"] += 1
+            attempt = counters["always_503"]
+        return jsonify({"attempt": attempt, "ok": False}), 503
+
+    return app
+
+
+app = create_app()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=1199)
+    parser.add_argument("--host", default="0.0.0.0")
+    args = parser.parse_args()
+    app.run(host=args.host, port=args.port)

--- a/test/registry-mocked/.gitignore
+++ b/test/registry-mocked/.gitignore
@@ -1,2 +1,6 @@
 *
 !.gitignore
+!src/
+src/*
+!src/retrytestprovider/
+!src/retrytestprovider/**

--- a/test/registry-mocked/src/retrytestprovider/v0.1.0/provider.yaml
+++ b/test/registry-mocked/src/retrytestprovider/v0.1.0/provider.yaml
@@ -1,0 +1,15 @@
+id: retrytestprovider
+name: retrytestprovider
+openapi: 3.0.3
+providerServices:
+  flaky:
+    description: Service backed by the local flask retry mock.
+    id: flaky:v0.1.0
+    name: flaky
+    preferred: true
+    service:
+      $ref: retrytestprovider/v0.1.0/services/flaky.yaml
+    title: Flaky service for retry policy testing
+    version: v0.1.0
+servers: []
+version: v0.1.0

--- a/test/registry-mocked/src/retrytestprovider/v0.1.0/services/flaky.yaml
+++ b/test/registry-mocked/src/retrytestprovider/v0.1.0/services/flaky.yaml
@@ -1,0 +1,204 @@
+components:
+  parameters:
+    fail_until:
+      in: query
+      name: fail_until
+      required: true
+      schema:
+        type: integer
+  schemas:
+    flaky_response:
+      properties:
+        key:
+          type: string
+        attempt:
+          type: integer
+        fail_until:
+          type: integer
+        ok:
+          type: boolean
+      type: object
+  x-stackQL-resources:
+    recoverable_default:
+      id: retrytestprovider.flaky.recoverable_default
+      name: recoverable_default
+      title: Recoverable using default retry policy (3 attempts)
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1flaky~1default-recover/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/recoverable_default/methods/get'
+        delete: []
+        insert: []
+        update: []
+    recoverable_configured:
+      id: retrytestprovider.flaky.recoverable_configured
+      name: recoverable_configured
+      title: Recoverable using configured 5-attempt policy
+      config:
+        retry:
+          algorithm: exponential
+          max_attempts: 5
+          initial_delay_ms: 5
+          max_delay_ms: 25
+          multiplier: 2
+          retryable_methods:
+            - GET
+          retryable_conditions:
+            status_codes:
+              - 503
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1flaky~1configured-recover/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '200'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/recoverable_configured/methods/get'
+        delete: []
+        insert: []
+        update: []
+    no_retry:
+      id: retrytestprovider.flaky.no_retry
+      name: no_retry
+      title: Single attempt only - retry disabled
+      config:
+        retry:
+          max_attempts: 1
+          initial_delay_ms: 1
+          max_delay_ms: 1
+          retryable_methods:
+            - GET
+          retryable_conditions:
+            status_codes:
+              - 503
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1always_503/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '503'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/no_retry/methods/get'
+        delete: []
+        insert: []
+        update: []
+    tight_budget:
+      id: retrytestprovider.flaky.tight_budget
+      name: tight_budget
+      title: Retry budget intentionally smaller than required failures
+      config:
+        retry:
+          max_attempts: 2
+          initial_delay_ms: 5
+          max_delay_ms: 10
+          retryable_methods:
+            - GET
+          retryable_conditions:
+            status_codes:
+              - 503
+      methods:
+        get:
+          operation:
+            $ref: '#/paths/~1flaky~1tight-budget/get'
+          response:
+            mediaType: application/json
+            openAPIDocKey: '503'
+      sqlVerbs:
+        select:
+          - $ref: '#/components/x-stackQL-resources/tight_budget/methods/get'
+        delete: []
+        insert: []
+        update: []
+info:
+  title: Flaky service for retry policy testing
+  version: 0.1.0
+openapi: 3.0.3
+paths:
+  /flaky/default-recover:
+    get:
+      operationId: flaky/default-recover
+      parameters:
+        - $ref: '#/components/parameters/fail_until'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: OK
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: Transient failure
+      servers:
+        - url: http://localhost:1199
+      summary: Recover via default retry policy
+  /flaky/configured-recover:
+    get:
+      operationId: flaky/configured-recover
+      parameters:
+        - $ref: '#/components/parameters/fail_until'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: OK
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: Transient failure
+      servers:
+        - url: http://localhost:1199
+      summary: Recover via configured 5-attempt retry policy
+  /flaky/tight-budget:
+    get:
+      operationId: flaky/tight-budget
+      parameters:
+        - $ref: '#/components/parameters/fail_until'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: OK
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: Transient failure
+      summary: Tight retry budget that should exhaust
+      servers:
+        - url: http://localhost:1199
+  /always_503:
+    get:
+      operationId: always_503
+      responses:
+        '503':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/flaky_response'
+          description: Always 503
+      summary: Always returns 503
+      servers:
+        - url: http://localhost:1199
+servers:
+  - url: http://localhost:1199

--- a/test/robot/cli/mocked/adhoc.robot
+++ b/test/robot/cli/mocked/adhoc.robot
@@ -2,6 +2,14 @@
 Resource          ${CURDIR}/anysdk_mocked.resource
 Test Teardown     AnySDK Per Test Teardown
 
+*** Variables ***
+${RETRY_MOCK_HOST}      127.0.0.1
+${RETRY_MOCK_PORT}      1199
+${RETRY_MOCK_BASE}      http://${RETRY_MOCK_HOST}:${RETRY_MOCK_PORT}
+${RETRY_PROV_PATH}      test/registry-mocked/src/retrytestprovider/v0.1.0/provider.yaml
+${RETRY_SVC_PATH}       test/registry-mocked/src/retrytestprovider/v0.1.0/services/flaky.yaml
+${RETRY_AUTH_JSON}      {"retrytestprovider": {"type": "null_auth"}}
+
 *** Test Cases *** 
 Select Google Cloud Storage Buckets with CLI
     [Documentation]    Test CLI Working
@@ -75,6 +83,134 @@ AWS EC2 Describe Volumes Demonstrates No Request Body Parameters Still Expands T
     Log    Stdout = ${result.stdout}
     Log    RC = ${result.rc}
     Should Be Equal As Strings    ${result.rc}    0
-    Should Contain                     ${result.stdout}    
+    Should Contain                     ${result.stdout}
     ...                                vol\-00100000000000000
     Should Be Equal               ${result.stderr}        ${EMPTY}
+
+Default Retry Policy Recovers After Transient 503s
+    [Documentation]    Default policy (3 attempts) — server fails twice then succeeds.
+    [Tags]    cli    retry
+    Ensure Retry Mock Running
+    Reset Retry Mock Counters
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    query
+    ...    \-\-prov-file-path         ${RETRY_PROV_PATH}
+    ...    \-\-svc-file-path          ${RETRY_SVC_PATH}
+    ...    \-\-resource               recoverable_default
+    ...    \-\-method                 get
+    ...    \-\-parameters             {"fail_until": 2}
+    ...    \-\-auth                   ${RETRY_AUTH_JSON}
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}Default-Retry-Policy-Recovers.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}Default-Retry-Policy-Recovers_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Should Be Equal As Strings    ${result.rc}    0
+    Should Contain                ${result.stdout}    "ok":true
+    Should Contain                ${result.stdout}    "attempt":3
+    Assert Mock Attempts          default-recover    3
+
+Configured Retry Policy Recovers On Fifth Attempt
+    [Documentation]    Resource-level config (max_attempts=5) — server fails four times then succeeds.
+    [Tags]    cli    retry
+    Ensure Retry Mock Running
+    Reset Retry Mock Counters
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    query
+    ...    \-\-prov-file-path         ${RETRY_PROV_PATH}
+    ...    \-\-svc-file-path          ${RETRY_SVC_PATH}
+    ...    \-\-resource               recoverable_configured
+    ...    \-\-method                 get
+    ...    \-\-parameters             {"fail_until": 4}
+    ...    \-\-auth                   ${RETRY_AUTH_JSON}
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}Configured-Retry-Policy-Recovers.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}Configured-Retry-Policy-Recovers_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Should Be Equal As Strings    ${result.rc}    0
+    Should Contain                ${result.stdout}    "ok":true
+    Should Contain                ${result.stdout}    "attempt":5
+    Assert Mock Attempts          configured-recover    5
+
+Zero Retry Policy Issues Exactly One Attempt
+    [Documentation]    Resource-level config max_attempts=1 disables retry entirely.
+    [Tags]    cli    retry
+    Ensure Retry Mock Running
+    Reset Retry Mock Counters
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    query
+    ...    \-\-prov-file-path         ${RETRY_PROV_PATH}
+    ...    \-\-svc-file-path          ${RETRY_SVC_PATH}
+    ...    \-\-resource               no_retry
+    ...    \-\-method                 get
+    ...    \-\-auth                   ${RETRY_AUTH_JSON}
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}Zero-Retry-Single-Attempt.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}Zero-Retry-Single-Attempt_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Should Contain                ${result.stdout}    "ok":false
+    Should Contain                ${result.stdout}    "attempt":1
+    Should Contain                ${result.stderr}    503
+    Assert Mock Attempts          always_503    1
+
+Tight Retry Budget Surfaces Final 503
+    [Documentation]    Resource-level config max_attempts=2 with four required failures — should exhaust.
+    [Tags]    cli    retry
+    Ensure Retry Mock Running
+    Reset Retry Mock Counters
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    query
+    ...    \-\-prov-file-path         ${RETRY_PROV_PATH}
+    ...    \-\-svc-file-path          ${RETRY_SVC_PATH}
+    ...    \-\-resource               tight_budget
+    ...    \-\-method                 get
+    ...    \-\-parameters             {"fail_until": 4}
+    ...    \-\-auth                   ${RETRY_AUTH_JSON}
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}Tight-Retry-Budget.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}Tight-Retry-Budget_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Should Contain                ${result.stdout}    "ok":false
+    Should Contain                ${result.stdout}    "attempt":2
+    Should Contain                ${result.stderr}    503
+    Assert Mock Attempts          tight-budget    2
+
+*** Keywords ***
+Ensure Retry Mock Running
+    [Documentation]    Confirm the local flask retry mock is reachable. CI starts it
+    ...                ahead of time; for local dev we'll spin it up on demand.
+    ${ping} =    Run Process    curl    -sf    -X    POST    ${RETRY_MOCK_BASE}/reset
+    Log    Ping rc=${ping.rc} stdout=${ping.stdout} stderr=${ping.stderr}
+    IF    '${ping.rc}' == '0'    RETURN
+    Create Directory                  ${CURDIR}${/}tmp
+    Start Process    flask    --app\=test/python/any_sdk_test_utils/mocks/retry_app:app    run    --host    ${RETRY_MOCK_HOST}    --port    ${RETRY_MOCK_PORT}
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    alias=retry_mock_server
+    ...    stdout=${CURDIR}${/}tmp${/}retry_mock_stdout.log
+    ...    stderr=${CURDIR}${/}tmp${/}retry_mock_stderr.log
+    ${started} =    Run Keyword And Return Status    Wait Until Keyword Succeeds    60x    500ms    Reset Retry Mock Counters
+    IF    not ${started}    Log Retry Mock Diagnostics
+    Should Be True    ${started}    Retry mock did not become reachable on ${RETRY_MOCK_BASE}
+
+Log Retry Mock Diagnostics
+    ${stdout_exists} =    Run Keyword And Return Status    File Should Exist    ${CURDIR}${/}tmp${/}retry_mock_stdout.log
+    ${stderr_exists} =    Run Keyword And Return Status    File Should Exist    ${CURDIR}${/}tmp${/}retry_mock_stderr.log
+    IF    ${stdout_exists}    Log File    ${CURDIR}${/}tmp${/}retry_mock_stdout.log
+    IF    ${stderr_exists}    Log File    ${CURDIR}${/}tmp${/}retry_mock_stderr.log
+
+Reset Retry Mock Counters
+    ${reset} =    Run Process    curl    -sf    -X    POST    ${RETRY_MOCK_BASE}/reset
+    Should Be Equal As Strings    ${reset.rc}    0    Reset call to ${RETRY_MOCK_BASE}/reset returned rc=${reset.rc} stdout='${reset.stdout}' stderr='${reset.stderr}'
+
+Assert Mock Attempts
+    [Arguments]    ${key}    ${expected}
+    ${count} =    Run Process    curl    -sf    ${RETRY_MOCK_BASE}/count/${key}
+    Should Be Equal As Strings    ${count.rc}    0
+    Should Contain                ${count.stdout}    "attempts":${expected}


### PR DESCRIPTION
## Summary

- Support for policy based retry logic.
- Added robot test `Default Retry Policy Recovers After Transient 503s`.
- Added robot test `Configured Retry Policy Recovers On Fifth Attempt`.
- Added robot test `Zero Retry Policy Issues Exactly One Attempt`.
- Added robot test `Tight Retry Budget Surfaces Final 503`.