### PR TITLE
path-params-contain-slashes

### DIFF
--- a/docs/parameters_containing_slash.md
+++ b/docs/parameters_containing_slash.md
@@ -1,0 +1,125 @@
+# Path parameters containing forward slashes
+
+Several upstream APIs use **resource-name** style path parameters whose value
+itself contains `/` characters — for example, GCP's `name`:
+
+```
+projects/my-project/locations/us-central1/keyRings/my-ring
+```
+
+Until now, these values could not be carried through any-sdk's request flow.
+This document records what changed, why, and the one authoring constraint the
+fix imposes on OpenAPI specs.
+
+## What used to break
+
+The validation router used by `parameterize()` is built on
+`github.com/gorilla/mux`. When a route like `/v1/{name}/keys` is registered,
+mux compiles the placeholder `{name}` to its default per-segment regex,
+`[^/]+`. A path-parameter value containing `/` therefore failed to match,
+`router.FindRoute` returned `ErrPathNotFound`, and the request never left the
+client — even though the substituted URL itself was correct.
+
+Anatomy of the failure path:
+
+- [internal/anysdk/operation_store.go:1506](../internal/anysdk/operation_store.go#L1506) — substitutes path-param values literally; slashes survive.
+- [pkg/queryrouter/queryrouter.go:107](../pkg/queryrouter/queryrouter.go#L107) — `muxRouter.Path("/v1/{name}")` registers with the default `[^/]+` regex.
+- [internal/anysdk/operation_store.go:1528](../internal/anysdk/operation_store.go#L1528) — `router.FindRoute(httpReq)` returns `ErrPathNotFound`.
+
+## The fix
+
+`pkg/queryrouter/queryrouter.go` rewrites OpenAPI placeholders in the path
+template at route-registration time. The rewrite is *selective*: it applies
+only to placeholders where mux can unambiguously split the captured value:
+
+| Source template                       | Registered with mux as                                |
+| ------------------------------------- | ----------------------------------------------------- |
+| `/v1/{name}/keys`                     | `/v1/{name:[^?#]+}/keys`                              |
+| `/v1/{parent}/locations/{location}`   | `/v1/{parent:[^?#]+}/locations/{location:[^?#]+}`     |
+| `/v1/{id:[0-9]+}`                     | unchanged (already explicit)                          |
+| `/v1/{a}/{b}` (ambiguous adjacency)   | unchanged (both keep mux's default `[^/]+`)           |
+| `/v1/{a}/{b}/x/{c}`                   | `/v1/{a}/{b}/x/{c:[^?#]+}` (only `{c}` is rewritten)  |
+
+The regex `[^?#]+` permits anything except the path-terminating characters
+`?` (start of query) and `#` (start of fragment) — i.e. `/` is allowed inside
+a captured value. mux's greedy matcher backtracks until the surrounding
+literal segments line up, so `/v1/{parent}/locations/{location}` against
+`/v1/projects/p1/folders/f2/locations/us-central1/sub` correctly resolves
+to `parent = "projects/p1/folders/f2"` and `location = "us-central1/sub"`.
+
+Substitution itself is unchanged — `replaceSimpleStringVars` still emits
+literal `/` into the URL. That is what most resource-name APIs (GCP, Azure,
+Vault, etc.) actually expect on the wire.
+
+The rewrite lives in `permitSlashesInPathParams` in
+[pkg/queryrouter/queryrouter.go](../pkg/queryrouter/queryrouter.go); behaviour is
+covered by tests in
+[pkg/queryrouter/queryrouter_test.go](../pkg/queryrouter/queryrouter_test.go).
+
+## Known limitation: ambiguous adjacency
+
+The rewrite relies on a literal segment between any two slashy path
+parameters to anchor the regex split. If the template has two placeholders
+with no disambiguating literal between them — e.g.
+
+```
+/v1/{a}/{b}        # only `/` between
+/v1/{a}{b}         # nothing between
+/v1/{a}//{b}       # only slashes between
+```
+
+— gorilla/mux's greedy regex cannot reliably split the captured values.
+
+**For these cases the fix simply doesn't apply.** Both placeholders keep
+mux's default `[^/]+` matcher: existing slash-free values keep routing
+exactly as they did before this change, and slashy values still fail with
+`ErrPathNotFound` at runtime — same as the pre-fix world. Other path
+parameters in the same spec, in other operations, still benefit from the
+rewrite normally.
+
+### Surfacing in `aot`
+
+The static analyser (`aot` CLI) runs `checkPathParamAdjacency` on every
+operation. A template with ambiguous adjacency produces a **warning**-level
+finding tagged with bin `path-param-adjacent` and an explanatory message
+naming the offending template. The finding flows through both:
+
+- the per-finding JSONL stream on stderr (`{"level":"warning","bin":"path-param-adjacent",...}`); and
+- the stdout summary, where it is counted under `total_warnings` and binned
+  under `bins["path-param-adjacent"]`.
+
+The warning does **not** drive a non-zero exit code — it is informational,
+since the runtime behaviour is unchanged. CI pipelines that want to gate on
+this can grep for the bin name.
+
+The check is implemented at
+[public/discovery/method_analysis_checks.go](../public/discovery/method_analysis_checks.go)
+(`checkPathParamAdjacency` + `hasAdjacentPathParams`); wiring is in
+[public/discovery/static_analyzer.go](../public/discovery/static_analyzer.go)
+(`analyzeMethod`).
+
+### Remediations if you hit the warning and need slashy values
+
+1. **Insert a literal segment.** If the API actually expects a literal
+   between the two values (the usual case), put it back:
+   `/v1/{parent}/locations/{location}` instead of `/v1/{parent}/{location}`.
+2. **Collapse to a single parameter.** If the two values are always written
+   together in the URL (resource-name style), merge them at the spec level:
+   `/v1/{name}` where `name = "p/q/locations/us"`.
+3. **Pin an explicit regex.** If you genuinely have a constrained format —
+   for example `{id}` is always `[0-9]+` — write `{id:[0-9]+}` in the
+   template. The rewrite preserves explicit regexes verbatim, so mux can
+   disambiguate without backtracking.
+
+## Server-side caveat
+
+We deliberately do **not** percent-encode `/` to `%2F` during substitution.
+That alternative was considered and rejected: the encoded form satisfies the
+mux router but breaks for servers fronted by stacks that reject `%2F` in
+request paths (older Apache with `AllowEncodedSlashes off` is the canonical
+example). Sending the literal `/` matches what GCP, Azure, AWS resource ARNs
+and most modern REST APIs actually accept.
+
+If a target API ever requires the `%2F` form, the right place to opt in is a
+per-parameter flag on the OpenAPI spec, encoded into the substitution layer
+in `replaceSimpleStringVars`. That's not implemented today.

--- a/pkg/queryrouter/queryrouter.go
+++ b/pkg/queryrouter/queryrouter.go
@@ -104,7 +104,7 @@ func (r *Router) addRoutes(
 		if qmIxd > -1 {
 			strippedPath = path[:qmIxd]
 		}
-		muxRoute := muxRouter.Path(s.base + strippedPath).Methods(methods...)
+		muxRoute := muxRouter.Path(s.base + permitSlashesInPathParams(strippedPath)).Methods(methods...)
 		if qmIxd > -1 && len(path) > qmIxd {
 			var pairs []string
 			kvs := strings.Split(path[qmIxd+1:], "&")
@@ -183,6 +183,72 @@ func orderedPaths(paths map[string]*openapi3.PathItem) []string {
 		}
 	}
 	return ordered
+}
+
+// permitSlashesInPathParams rewrites OpenAPI-style `{name}` placeholders in a
+// path template to the gorilla/mux form `{name:[^?#]+}`, which allows the
+// captured value to span `/` characters. This is what enables path-parameter
+// values like `projects/foo/locations/us` (a single OpenAPI parameter whose
+// value happens to contain slashes) to route correctly through gorilla/mux —
+// mux's default per-segment regex (`[^/]+`) would otherwise reject them.
+//
+// Placeholders are NOT rewritten when they participate in an ambiguous
+// adjacency pair — i.e. two placeholders separated only by `/` characters
+// (or nothing at all). For those, mux's greedy regex cannot disambiguate
+// across slashes, so we preserve the default `[^/]+` matcher: existing
+// slash-free values keep routing exactly as before, and slashy values still
+// fail with `ErrPathNotFound` at runtime. The aot static analyser emits a
+// warning (`path-param-adjacent` bin) for these templates so authors are
+// notified — see docs/parameters_containing_slash.md.
+//
+// Placeholders that already carry an explicit regex (`{name:...}`) are left
+// untouched, as are stray braces that are not well-formed placeholders.
+func permitSlashesInPathParams(path string) string {
+	type span struct{ start, end int } // inclusive indices of '{' and '}'
+	var spans []span
+	for i := 0; i < len(path); {
+		open := strings.IndexByte(path[i:], '{')
+		if open < 0 {
+			break
+		}
+		open += i
+		closeIdx := strings.IndexByte(path[open:], '}')
+		if closeIdx < 0 {
+			break
+		}
+		closeIdx += open
+		spans = append(spans, span{open, closeIdx})
+		i = closeIdx + 1
+	}
+	if len(spans) == 0 {
+		return path
+	}
+	ambiguous := make([]bool, len(spans))
+	for k := 0; k < len(spans)-1; k++ {
+		between := path[spans[k].end+1 : spans[k+1].start]
+		if strings.Trim(between, "/") == "" {
+			ambiguous[k] = true
+			ambiguous[k+1] = true
+		}
+	}
+	var b strings.Builder
+	b.Grow(len(path) + 8*len(spans))
+	cursor := 0
+	for k, sp := range spans {
+		b.WriteString(path[cursor:sp.start])
+		body := path[sp.start+1 : sp.end]
+		simpleName := body != "" && !strings.ContainsRune(body, ':') && !strings.ContainsRune(body, '{')
+		if simpleName && !ambiguous[k] {
+			b.WriteByte('{')
+			b.WriteString(body)
+			b.WriteString(":[^?#]+}")
+		} else {
+			b.WriteString(path[sp.start : sp.end+1])
+		}
+		cursor = sp.end + 1
+	}
+	b.WriteString(path[cursor:])
+	return b.String()
 }
 
 // Magic strings that temporarily replace "{}" so net/url.Parse() works

--- a/pkg/queryrouter/queryrouter_test.go
+++ b/pkg/queryrouter/queryrouter_test.go
@@ -1,6 +1,7 @@
 package queryrouter
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -92,5 +93,162 @@ func TestServerTemplate_RegexClusterAddr_Works(t *testing.T) {
 
 	if _, err := NewRouter(doc); err != nil {
 		t.Fatalf("regex cluster_addr server template should work, got error: %v", err)
+	}
+}
+
+/*
+CASE 4
+Path parameter value contains forward slashes (resource-name style).
+Template: /v1/{name}/keys
+Request:  /v1/projects/p1/locations/us/keyRings/r1/keys
+Expected: matches; name = "projects/p1/locations/us/keyRings/r1"
+*/
+func TestPathParam_SingleSlashyParam_Matches(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Servers: openapi3.Servers{{URL: "https://example.com"}},
+		Paths: openapi3.Paths{
+			"/v1/{name}/keys": &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					Parameters: openapi3.Parameters{
+						{Value: &openapi3.Parameter{Name: "name", In: "path", Required: true}},
+					},
+					Responses: openapi3.Responses{"200": &openapi3.ResponseRef{Value: &openapi3.Response{}}},
+				},
+			},
+		},
+	}
+	r, err := NewRouter(doc)
+	if err != nil {
+		t.Fatalf("NewRouter failed: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/v1/projects/p1/locations/us/keyRings/r1/keys", nil)
+	route, vars, err := r.FindRoute(req)
+	if err != nil {
+		t.Fatalf("FindRoute failed for slashy path-param value: %v", err)
+	}
+	if route == nil {
+		t.Fatalf("expected non-nil route")
+	}
+	if got, want := vars["name"], "projects/p1/locations/us/keyRings/r1"; got != want {
+		t.Fatalf("captured name = %q, want %q", got, want)
+	}
+}
+
+/*
+CASE 5
+Multiple path parameters separated by a literal segment, both values containing slashes.
+Template: /v1/{parent}/locations/{location}
+Request:  /v1/projects/p1/folders/f2/locations/us-central1/sub
+Expected: greedy backtracking lands on the literal `/locations/`,
+          giving parent = "projects/p1/folders/f2", location = "us-central1/sub".
+*/
+func TestPathParam_TwoParams_LiteralBetween_Matches(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Servers: openapi3.Servers{{URL: "https://example.com"}},
+		Paths: openapi3.Paths{
+			"/v1/{parent}/locations/{location}": &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					Parameters: openapi3.Parameters{
+						{Value: &openapi3.Parameter{Name: "parent", In: "path", Required: true}},
+						{Value: &openapi3.Parameter{Name: "location", In: "path", Required: true}},
+					},
+					Responses: openapi3.Responses{"200": &openapi3.ResponseRef{Value: &openapi3.Response{}}},
+				},
+			},
+		},
+	}
+	r, err := NewRouter(doc)
+	if err != nil {
+		t.Fatalf("NewRouter failed: %v", err)
+	}
+	req, _ := http.NewRequest("GET", "https://example.com/v1/projects/p1/folders/f2/locations/us-central1/sub", nil)
+	_, vars, err := r.FindRoute(req)
+	if err != nil {
+		t.Fatalf("FindRoute failed: %v", err)
+	}
+	if got, want := vars["parent"], "projects/p1/folders/f2"; got != want {
+		t.Fatalf("captured parent = %q, want %q", got, want)
+	}
+	if got, want := vars["location"], "us-central1/sub"; got != want {
+		t.Fatalf("captured location = %q, want %q", got, want)
+	}
+}
+
+/*
+CASE 6
+permitSlashesInPathParams: pure-string transform invariants.
+*/
+func TestPermitSlashesInPathParams_Rewrites(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"/v1/{name}/keys", "/v1/{name:[^?#]+}/keys"},
+		{"/v1/{parent}/locations/{location}", "/v1/{parent:[^?#]+}/locations/{location:[^?#]+}"},
+		// already-explicit regex preserved
+		{"/v1/{id:[0-9]+}", "/v1/{id:[0-9]+}"},
+		// no placeholders
+		{"/health", "/health"},
+		// empty braces left as-is
+		{"/v1/{}/x", "/v1/{}/x"},
+		// unmatched brace tolerated
+		{"/v1/{name", "/v1/{name"},
+		// Ambiguous adjacency: BOTH placeholders left at mux's default `[^/]+`.
+		{"/v1/{a}/{b}", "/v1/{a}/{b}"},
+		{"/v1/{a}{b}", "/v1/{a}{b}"},
+		// Mixed: ambiguous pair stays restrictive, anchored neighbour gets rewritten.
+		{"/v1/{a}/{b}/x/{c}", "/v1/{a}/{b}/x/{c:[^?#]+}"},
+	}
+	for _, c := range cases {
+		if got := permitSlashesInPathParams(c.in); got != c.want {
+			t.Fatalf("permitSlashesInPathParams(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+/*
+CASE 7
+Ambiguous adjacency template `/{a}/{b}` keeps routing slash-free values
+exactly as before — proves the selective skip is non-regressing for
+existing specs.
+*/
+func TestPathParam_AdjacentPair_NoRegressionForSlashFreeValues(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.3",
+		Servers: openapi3.Servers{{URL: "https://example.com"}},
+		Paths: openapi3.Paths{
+			"/v1/{a}/{b}": &openapi3.PathItem{
+				Get: &openapi3.Operation{
+					Parameters: openapi3.Parameters{
+						{Value: &openapi3.Parameter{Name: "a", In: "path", Required: true}},
+						{Value: &openapi3.Parameter{Name: "b", In: "path", Required: true}},
+					},
+					Responses: openapi3.Responses{"200": &openapi3.ResponseRef{Value: &openapi3.Response{}}},
+				},
+			},
+		},
+	}
+	r, err := NewRouter(doc)
+	if err != nil {
+		t.Fatalf("NewRouter failed: %v", err)
+	}
+	// Slash-free values: must match.
+	req, _ := http.NewRequest("GET", "https://example.com/v1/foo/bar", nil)
+	_, vars, err := r.FindRoute(req)
+	if err != nil {
+		t.Fatalf("FindRoute failed for slash-free values on adjacent template: %v", err)
+	}
+	if got := vars["a"]; got != "foo" {
+		t.Fatalf("captured a = %q, want %q", got, "foo")
+	}
+	if got := vars["b"]; got != "bar" {
+		t.Fatalf("captured b = %q, want %q", got, "bar")
+	}
+	// Slashy value: must NOT match — the adjacency check is documented as
+	// the boundary where slash support breaks down.
+	req2, _ := http.NewRequest("GET", "https://example.com/v1/foo/extra/bar", nil)
+	if _, _, err := r.FindRoute(req2); err == nil {
+		t.Fatalf("expected FindRoute to fail for slashy value on adjacent template, got nil error")
 	}
 }

--- a/public/discovery/method_analysis_checks.go
+++ b/public/discovery/method_analysis_checks.go
@@ -16,6 +16,7 @@ const (
 	BinServerURLInvalid         = "server-url-invalid"
 	BinPaginationIncomplete     = "pagination-incomplete"
 	BinTransformSchemaMismatch  = "transform-schema-mismatch"
+	BinPathParamAdjacent        = "path-param-adjacent"
 )
 
 // checkRequestParamRoutability validates that required parameters have
@@ -215,6 +216,72 @@ func checkCrossResourceConsistency(
 		})
 	}
 	return findings
+}
+
+// checkPathParamAdjacency flags OpenAPI path templates where two path
+// parameters appear with no disambiguating literal text between them — e.g.
+// `/{a}/{b}` or `/{a}{b}`.
+//
+// Background: queryrouter's `permitSlashesInPathParams` rewrites
+// path-parameter placeholders so their values may contain `/`. That rewrite
+// is selectively skipped for ambiguous adjacency pairs, because
+// gorilla/mux's greedy regex cannot reliably split values across a
+// slash-only boundary. The runtime behaviour for those templates is
+// unchanged from the pre-fix world (slashy values still fail with
+// `ErrPathNotFound`), but authors should know which params are stuck.
+//
+// This check therefore produces a WARNING-level finding so it surfaces in
+// `aot` output without blocking exit.
+func checkPathParamAdjacency(
+	actx AnalysisContext,
+	method anysdk.StandardOperationStore,
+) []AnalysisFinding {
+	opRef := method.GetOperationRef()
+	if opRef == nil {
+		return nil
+	}
+	path := opRef.ExtractPathItem()
+	if !hasAdjacentPathParams(path) {
+		return nil
+	}
+	return []AnalysisFinding{
+		actx.NewWarning(BinPathParamAdjacent,
+			fmt.Sprintf("path template %q has adjacent path parameters with no literal segment between them; values containing '/' will not route through these params (see docs/parameters_containing_slash.md)", path)),
+	}
+}
+
+// hasAdjacentPathParams reports whether two path-parameter placeholders in
+// `path` appear with no literal disambiguator between them. The text between
+// two consecutive placeholders is "literal" only if it contains characters
+// other than `/` — bare `/` between `{a}` and `{b}` does NOT separate them
+// once values may contain `/` themselves.
+func hasAdjacentPathParams(path string) bool {
+	if path == "" {
+		return false
+	}
+	prevEnd := -1
+	i := 0
+	for i < len(path) {
+		open := strings.IndexByte(path[i:], '{')
+		if open < 0 {
+			return false
+		}
+		open += i
+		close := strings.IndexByte(path[open:], '}')
+		if close < 0 {
+			return false
+		}
+		close += open
+		if prevEnd >= 0 {
+			between := path[prevEnd+1 : open]
+			if strings.Trim(between, "/") == "" {
+				return true
+			}
+		}
+		prevEnd = close
+		i = close + 1
+	}
+	return false
 }
 
 // checkTransformSchemaConsistency validates that when a response has both

--- a/public/discovery/method_analysis_checks_test.go
+++ b/public/discovery/method_analysis_checks_test.go
@@ -1,0 +1,31 @@
+package discovery
+
+import "testing"
+
+func TestHasAdjacentPathParams(t *testing.T) {
+	cases := []struct {
+		name string
+		path string
+		want bool
+	}{
+		// Safe: literal segment separates the two placeholders.
+		{"two params with literal between", "/v1/{parent}/locations/{location}", false},
+		{"single param", "/v1/{name}/keys", false},
+		{"no params", "/health", false},
+		{"empty", "", false},
+		// Violations: nothing or only `/` between two placeholders.
+		{"slash-only between", "/v1/{a}/{b}", true},
+		{"directly adjacent", "/v1/{a}{b}", true},
+		{"multi-slash between", "/v1/{a}//{b}", true},
+		// Three params: only the offending pair needs to violate.
+		{"three params, last pair violates", "/v1/{a}/x/{b}/{c}", true},
+		{"three params, all anchored by literals", "/v1/{a}/x/{b}/y/{c}", false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := hasAdjacentPathParams(c.path); got != c.want {
+				t.Fatalf("hasAdjacentPathParams(%q) = %v, want %v", c.path, got, c.want)
+			}
+		})
+	}
+}

--- a/public/discovery/static_analyzer.go
+++ b/public/discovery/static_analyzer.go
@@ -1441,6 +1441,7 @@ func analyzeMethod(
 	result.findings = append(result.findings, checkServerURLValidity(actx, method)...)
 	result.findings = append(result.findings, checkPaginationCompleteness(actx, method)...)
 	result.findings = append(result.findings, checkTransformSchemaConsistency(actx, method)...)
+	result.findings = append(result.findings, checkPathParamAdjacency(actx, method)...)
 
 	switch protocolType {
 	case client.HTTP:

--- a/test/robot/cli/aot/aot_adhoc.robot
+++ b/test/robot/cli/aot/aot_adhoc.robot
@@ -170,6 +170,76 @@ AOT Method Level Analysis AWS EC2 volumes_post_naively_presented describeVolumes
     ...                                ec2.volumes_post_naively_presented
     Should Be Equal As Strings    ${result.rc}    0
 
+AOT Provider Level Analysis Contrived Provider Surfaces Path Param Adjacency Warning
+    [Documentation]    Path template /repos/{owner}/{repo}/pages has two path parameters
+    ...                separated only by '/' — gorilla/mux cannot disambiguate slashy
+    ...                values across that boundary. The aot CLI must surface a warning
+    ...                (not an error) so spec authors notice without the build failing.
+    ...                See docs/parameters_containing_slash.md.
+    [Tags]    cli    aot    path-param-slash
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    aot
+    ...    \./test/registry
+    ...    \./test/registry/src/contrivedprovider/v0\.1\.0/provider\.yaml
+    ...    \-\-schema-dir
+    ...    cicd/schema-definitions
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}AOT-Contrived-Provider-Path-Param-Adjacency.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}AOT-Contrived-Provider-Path-Param-Adjacency_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Log    RC = ${result.rc}
+    # stderr: structured JSONL warning includes bin, the offending template, and the doc pointer.
+    Should Contain                     ${result.stderr}
+    ...                                "level":"warning"
+    Should Contain                     ${result.stderr}
+    ...                                "bin":"path-param-adjacent"
+    Should Contain                     ${result.stderr}
+    ...                                /repos/{owner}/{repo}/pages
+    Should Contain                     ${result.stderr}
+    ...                                docs/parameters_containing_slash.md
+    # stdout: summary counts the warning and bins it under the offending resource.
+    Should Contain                     ${result.stdout}
+    ...                                "path-param-adjacent"
+    Should Contain                     ${result.stdout}
+    ...                                contrived_service.pages
+    # Adjacency is informational, not fatal — exit code stays 0.
+    Should Be Equal As Strings    ${result.rc}    0
+
+AOT Method Level Analysis AWS EC2 Has No Spurious Path Param Adjacency Warning
+    [Documentation]    Regression guard: well-anchored OpenAPI templates (literal segments
+    ...                between every pair of path placeholders) must NOT emit any
+    ...                path-param-adjacent finding. If this fires, hasAdjacentPathParams
+    ...                has gained a false-positive case.
+    [Tags]    cli    aot    path-param-slash
+    ${result} =    Run Process
+    ...    ${CLI_EXE}
+    ...    aot
+    ...    \-v
+    ...    \./test/registry
+    ...    \./test/registry/src/aws/v0\.1\.0/provider\.yaml
+    ...    ec2
+    ...    \-\-provider
+    ...    aws
+    ...    \-\-resource
+    ...    volumes_post_naively_presented
+    ...    \-\-method
+    ...    describeVolumes
+    ...    \-\-schema-dir
+    ...    cicd/schema-definitions
+    ...    cwd=${CWD_FOR_EXEC}
+    ...    stdout=${CURDIR}${/}/tmp${/}AOT-AWS-EC2-No-Path-Param-Adjacency.txt
+    ...    stderr=${CURDIR}${/}/tmp${/}AOT-AWS-EC2-No-Path-Param-Adjacency_stderr.txt
+    Log    Stderr = ${result.stderr}
+    Log    Stdout = ${result.stdout}
+    Log    RC = ${result.rc}
+    Should Not Contain                 ${result.stderr}
+    ...                                "bin":"path-param-adjacent"
+    Should Not Contain                 ${result.stdout}
+    ...                                "path-param-adjacent"
+    Should Be Equal As Strings    ${result.rc}    0
+
 Closure Generation AWS EC2 volumes_post_naively_presented with Rewrite
     [Documentation]    Test closure generation with server URL rewrite produces valid minimal service doc
     [Tags]    cli    closure


### PR DESCRIPTION
## Summary

- Permit path params to contain slashes where there are **not** adjacent params `{a}/{b}`.
- Added robot test `AOT Provider Level Analysis Contrived Provider Surfaces Path Param Adjacency Warning`.
- Added robot test `AOT Method Level Analysis AWS EC2 Has No Spurious Path Param Adjacency Warning`.