### PR TITLE
feat(pagination): add page_number algorithm for total_pages-based APIs

### DIFF
--- a/docs/provider_spec.md
+++ b/docs/provider_spec.md
@@ -695,6 +695,35 @@ pagination:
     algorithm: link_header_next
 ```
 
+### Page Number Pagination (Cloudflare V4, Atlassian, ServiceNow, ...)
+
+For APIs that report the current page and total page count in the response
+body — and therefore cannot signal completion via an empty token —
+set `algorithm: page_number` at the pagination block. The loop terminates
+when the current page number reaches the page-count terminator.
+
+```yaml
+pagination:
+  algorithm: page_number
+  requestToken:
+    key: page
+    location: query
+  responseToken:
+    key: result_info.page          # current page number in the response
+    location: body
+  responseTerminator:
+    key: result_info.total_pages   # total page count to compare against
+    location: body
+```
+
+Semantics:
+
+- The `requestToken.key` is the page-number request field (query/header/body).
+- The `responseToken.key` resolves to the **current** page number in the response.
+- The `responseTerminator.key` resolves to the **page count** to compare against.
+- Termination: `responseToken >= responseTerminator`, or either value missing / unparseable.
+- Increment: next request sends `current + 1`.
+
 ---
 
 ## Query Parameter Pushdown

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -96,7 +96,9 @@ type OperationStore interface {
 	GetOptionalParameters() map[string]Addressable
 	GetParameter(paramKey string) (Addressable, bool)
 	GetUnionRequiredParameters() (map[string]Addressable, error)
+	GetPaginationAlgorithm() string
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	MarshalBody(body interface{}, expectedRequest ExpectedRequest) dto.MarshalledBody
 	GetRequestBodySchema() (Schema, error)
 	GetNonBodyParameters() map[string]Addressable
@@ -645,6 +647,66 @@ func (op *standardOpenAPIOperationStore) GetPaginationResponseTokenSemantic() (T
 	}
 	if op.Provider != nil {
 		if ts, ok := op.ProviderService.getPaginationResponseTokenSemantic(); ok {
+			return ts, true
+		}
+	}
+	return nil, false
+}
+
+func (op *standardOpenAPIOperationStore) GetPaginationAlgorithm() string {
+	if op.StackQLConfig != nil {
+		pag, pagExists := op.StackQLConfig.GetPagination()
+		if pagExists && pag.GetAlgorithm() != "" {
+			return pag.GetAlgorithm()
+		}
+	}
+	if op.Resource != nil {
+		if a := op.Resource.GetPaginationAlgorithm(); a != "" {
+			return a
+		}
+	}
+	if op.OpenAPIService != nil {
+		if a := op.OpenAPIService.getPaginationAlgorithm(); a != "" {
+			return a
+		}
+	}
+	if op.ProviderService != nil {
+		if a := op.ProviderService.GetPaginationAlgorithm(); a != "" {
+			return a
+		}
+	}
+	if op.Provider != nil {
+		if a := op.Provider.GetPaginationAlgorithm(); a != "" {
+			return a
+		}
+	}
+	return ""
+}
+
+func (op *standardOpenAPIOperationStore) GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	if op.StackQLConfig != nil {
+		pag, pagExists := op.StackQLConfig.GetPagination()
+		if pagExists && pag.GetResponseTerminator() != nil {
+			return pag.GetResponseTerminator(), true
+		}
+	}
+	if op.Resource != nil {
+		if ts, ok := op.Resource.GetPaginationResponseTerminatorTokenSemantic(); ok {
+			return ts, true
+		}
+	}
+	if op.OpenAPIService != nil {
+		if ts, ok := op.OpenAPIService.getPaginationResponseTerminatorTokenSemantic(); ok {
+			return ts, true
+		}
+	}
+	if op.ProviderService != nil {
+		if ts, ok := op.ProviderService.getPaginationResponseTerminatorTokenSemantic(); ok {
+			return ts, true
+		}
+	}
+	if op.Provider != nil {
+		if ts, ok := op.Provider.GetPaginationResponseTerminatorTokenSemantic(); ok {
 			return ts, true
 		}
 	}

--- a/internal/anysdk/pagination.go
+++ b/internal/anysdk/pagination.go
@@ -15,15 +15,30 @@ var (
 	_              jsonpointer.JSONPointable = standardPagination{}
 )
 
+const (
+	// PaginationAlgorithmPageNumber identifies the page-number + total-pages
+	// pagination strategy: termination is by comparing the current page number
+	// in the response against a page-count field (`responseTerminator`).
+	PaginationAlgorithmPageNumber = "page_number"
+)
+
 type Pagination interface {
 	JSONLookup(token string) (interface{}, error)
+	GetAlgorithm() string
 	GetRequestToken() TokenSemantic
 	GetResponseToken() TokenSemantic
+	GetResponseTerminator() TokenSemantic
 }
 
 type standardPagination struct {
-	RequestToken  *standardTokenSemantic `json:"requestToken,omitempty" yaml:"requestToken,omitempty"`
-	ResponseToken *standardTokenSemantic `json:"responseToken,omitempty" yaml:"responseToken,omitempty"`
+	Algorithm          string                 `json:"algorithm,omitempty" yaml:"algorithm,omitempty"`
+	RequestToken       *standardTokenSemantic `json:"requestToken,omitempty" yaml:"requestToken,omitempty"`
+	ResponseToken      *standardTokenSemantic `json:"responseToken,omitempty" yaml:"responseToken,omitempty"`
+	ResponseTerminator *standardTokenSemantic `json:"responseTerminator,omitempty" yaml:"responseTerminator,omitempty"`
+}
+
+func (qt *standardPagination) GetAlgorithm() string {
+	return qt.Algorithm
 }
 
 func (qt *standardPagination) GetRequestToken() TokenSemantic {
@@ -34,15 +49,32 @@ func (qt *standardPagination) GetResponseToken() TokenSemantic {
 	return qt.ResponseToken
 }
 
+func (qt *standardPagination) GetResponseTerminator() TokenSemantic {
+	if qt.ResponseTerminator == nil {
+		return nil
+	}
+	return qt.ResponseTerminator
+}
+
 func (qt standardPagination) JSONLookup(token string) (interface{}, error) {
 	switch token {
+	case "algorithm":
+		return qt.Algorithm, nil
 	case "requestToken":
 		return qt.RequestToken, nil
 	case "responseToken":
 		return qt.ResponseToken, nil
+	case "responseTerminator":
+		return qt.ResponseTerminator, nil
 	default:
 		return nil, fmt.Errorf("could not resolve token '%s' from QueryTranspose doc object", token)
 	}
+}
+
+// GetTestingPagination returns a zero-value Pagination for testing.
+// Mirrors the GetTestingQueryParamPushdown helper convention.
+func GetTestingPagination() standardPagination {
+	return standardPagination{}
 }
 
 type TokenTransformer func(interface{}) (interface{}, error)

--- a/internal/anysdk/pagination_test.go
+++ b/internal/anysdk/pagination_test.go
@@ -1,0 +1,83 @@
+package anysdk_test
+
+import (
+	"testing"
+
+	. "github.com/stackql/any-sdk/internal/anysdk"
+	"gopkg.in/yaml.v3"
+
+	"gotest.tools/assert"
+)
+
+// TestPaginationPageNumberYAMLRoundTrip exercises the same YAML shape proposed
+// in issue #91 (algorithm at pagination level, current page in responseToken,
+// total page count in responseTerminator) and verifies the public Pagination
+// interface surfaces each field.
+func TestPaginationPageNumberYAMLRoundTrip(t *testing.T) {
+	input := `
+algorithm: page_number
+requestToken:
+  key: page
+  location: query
+responseToken:
+  key: result_info.page
+  location: body
+responseTerminator:
+  key: result_info.total_pages
+  location: body
+`
+	pag := GetTestingPagination()
+	if err := yaml.Unmarshal([]byte(input), &pag); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	assert.Equal(t, pag.GetAlgorithm(), PaginationAlgorithmPageNumber)
+
+	req := pag.GetRequestToken()
+	assert.Assert(t, req != nil, "expected requestToken to be non-nil")
+	assert.Equal(t, req.GetKey(), "page")
+	assert.Equal(t, req.GetLocation(), "query")
+
+	resp := pag.GetResponseToken()
+	assert.Assert(t, resp != nil, "expected responseToken to be non-nil")
+	assert.Equal(t, resp.GetKey(), "result_info.page")
+	assert.Equal(t, resp.GetLocation(), "body")
+
+	term := pag.GetResponseTerminator()
+	assert.Assert(t, term != nil, "expected responseTerminator to be non-nil")
+	assert.Equal(t, term.GetKey(), "result_info.total_pages")
+	assert.Equal(t, term.GetLocation(), "body")
+}
+
+// TestPaginationLegacyShapeNoAlgorithm verifies the existing token-based
+// configuration still unmarshals cleanly when no algorithm or
+// responseTerminator is supplied. Guards against breakage of the existing
+// token / offset / link strategies.
+func TestPaginationLegacyShapeNoAlgorithm(t *testing.T) {
+	input := `
+requestToken:
+  key: pageToken
+  location: query
+responseToken:
+  key: nextPageToken
+  location: body
+`
+	pag := GetTestingPagination()
+	if err := yaml.Unmarshal([]byte(input), &pag); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+	assert.Equal(t, pag.GetAlgorithm(), "")
+	req := pag.GetRequestToken()
+	assert.Assert(t, req != nil)
+	assert.Equal(t, req.GetKey(), "pageToken")
+	resp := pag.GetResponseToken()
+	assert.Assert(t, resp != nil)
+	assert.Equal(t, resp.GetKey(), "nextPageToken")
+	assert.Assert(t, pag.GetResponseTerminator() == nil, "expected no responseTerminator")
+}
+
+// TestPaginationAlgorithmConstant pins the exported algorithm identifier;
+// provider YAML and the invoker switch match on this exact string.
+func TestPaginationAlgorithmConstant(t *testing.T) {
+	assert.Equal(t, PaginationAlgorithmPageNumber, "page_number")
+}

--- a/internal/anysdk/provider.go
+++ b/internal/anysdk/provider.go
@@ -28,8 +28,10 @@ type Provider interface {
 	GetDeleteItemsKey() string
 	GetName() string
 	GetProviderServices() map[string]ProviderService
+	GetPaginationAlgorithm() string
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
 	GetRetryPolicy() (RetryPolicy, bool)
 	GetProviderService(key string) (ProviderService, error)
@@ -137,6 +139,20 @@ func (pr *standardProvider) GetPaginationResponseTokenSemantic() (TokenSemantic,
 		return nil, false
 	}
 	return pr.StackQLConfig.Pagination.ResponseToken, true
+}
+
+func (pr *standardProvider) GetPaginationAlgorithm() string {
+	if pr.StackQLConfig == nil || pr.StackQLConfig.Pagination == nil {
+		return ""
+	}
+	return pr.StackQLConfig.Pagination.Algorithm
+}
+
+func (pr *standardProvider) GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	if pr.StackQLConfig == nil || pr.StackQLConfig.Pagination == nil || pr.StackQLConfig.Pagination.ResponseTerminator == nil {
+		return nil, false
+	}
+	return pr.StackQLConfig.Pagination.ResponseTerminator, true
 }
 
 func (pr *standardProvider) GetQueryParamPushdown() (QueryParamPushdown, bool) {

--- a/internal/anysdk/providerService.go
+++ b/internal/anysdk/providerService.go
@@ -23,8 +23,10 @@ type ProviderService interface {
 	GetService() (Service, error)
 	GetRequestTranslateAlgorithm() string
 	GetResourcesShallow() (ResourceRegister, error)
+	GetPaginationAlgorithm() string
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	getPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	getPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
 	GetRetryPolicy() (RetryPolicy, bool)
 	ConditionIsValid(lhs string, rhs interface{}) bool
@@ -178,6 +180,20 @@ func (sv *standardProviderService) getPaginationResponseTokenSemantic() (TokenSe
 		return nil, false
 	}
 	return sv.StackQLConfig.Pagination.ResponseToken, true
+}
+
+func (sv *standardProviderService) GetPaginationAlgorithm() string {
+	if sv.StackQLConfig == nil || sv.StackQLConfig.Pagination == nil {
+		return ""
+	}
+	return sv.StackQLConfig.Pagination.Algorithm
+}
+
+func (sv *standardProviderService) getPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	if sv.StackQLConfig == nil || sv.StackQLConfig.Pagination == nil || sv.StackQLConfig.Pagination.ResponseTerminator == nil {
+		return nil, false
+	}
+	return sv.StackQLConfig.Pagination.ResponseTerminator, true
 }
 
 func (sv *standardProviderService) GetQueryParamPushdown() (QueryParamPushdown, bool) {

--- a/internal/anysdk/resource.go
+++ b/internal/anysdk/resource.go
@@ -25,8 +25,10 @@ type Resource interface {
 	GetMethods() Methods
 	GetServiceDocPath() *ServiceRef
 	GetRequestTranslateAlgorithm() string
+	GetPaginationAlgorithm() string
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
 	GetRetryPolicy() (RetryPolicy, bool)
 	FindMethod(key string) (StandardOperationStore, error)
@@ -198,6 +200,26 @@ func (r *standardResource) GetPaginationResponseTokenSemantic() (TokenSemantic, 
 		pag, pagExists := r.StackQLConfig.GetPagination()
 		if pagExists && pag.GetResponseToken() != nil {
 			return pag.GetResponseToken(), true
+		}
+	}
+	return nil, false
+}
+
+func (r *standardResource) GetPaginationAlgorithm() string {
+	if r.StackQLConfig != nil {
+		pag, pagExists := r.StackQLConfig.GetPagination()
+		if pagExists {
+			return pag.GetAlgorithm()
+		}
+	}
+	return ""
+}
+
+func (r *standardResource) GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	if r.StackQLConfig != nil {
+		pag, pagExists := r.StackQLConfig.GetPagination()
+		if pagExists && pag.GetResponseTerminator() != nil {
+			return pag.GetResponseTerminator(), true
 		}
 	}
 	return nil, false

--- a/internal/anysdk/service.go
+++ b/internal/anysdk/service.go
@@ -32,8 +32,10 @@ type OpenAPIService interface {
 	//
 	getRequestTranslateAlgorithm() string
 	getComponents() openapi3.Components
+	getPaginationAlgorithm() string
 	getPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	getPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	getPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	getQueryTransposeAlgorithm() string
 	getQueryParamPushdown() (QueryParamPushdown, bool)
 	getRetryPolicy() (RetryPolicy, bool)
@@ -279,6 +281,26 @@ func (svc *standardService) getPaginationResponseTokenSemantic() (TokenSemantic,
 		pag, pagExists := svc.StackQLConfig.GetPagination()
 		if pagExists && pag.GetResponseToken() != nil {
 			return pag.GetResponseToken(), true
+		}
+	}
+	return nil, false
+}
+
+func (svc *standardService) getPaginationAlgorithm() string {
+	if svc.StackQLConfig != nil {
+		pag, pagExists := svc.StackQLConfig.GetPagination()
+		if pagExists {
+			return pag.GetAlgorithm()
+		}
+	}
+	return ""
+}
+
+func (svc *standardService) getPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	if svc.StackQLConfig != nil {
+		pag, pagExists := svc.StackQLConfig.GetPagination()
+		if pagExists && pag.GetResponseTerminator() != nil {
+			return pag.GetResponseTerminator(), true
 		}
 	}
 	return nil, false

--- a/public/providerinvokers/anysdkhttp/invoker.go
+++ b/public/providerinvokers/anysdkhttp/invoker.go
@@ -1029,6 +1029,50 @@ func inferNextPageResponseElement(provider anysdk.Provider, method anysdk.Operat
 	}
 }
 
+func inferPageNumberTerminatorElement(method anysdk.OperationStore) sdk_internal_dto.HTTPElement {
+	st, ok := method.GetPaginationResponseTerminatorTokenSemantic()
+	if !ok {
+		return nil
+	}
+	tp, err := sdk_internal_dto.ExtractHTTPElement(st.GetLocation())
+	if err != nil {
+		return nil
+	}
+	rv := sdk_internal_dto.NewHTTPElement(tp, st.GetKey())
+	transformer, tErr := st.GetTransformer()
+	if tErr == nil && transformer != nil {
+		rv.SetTransformer(transformer)
+	}
+	return rv
+}
+
+// extractPageNumberNextToken implements the `page_number` pagination algorithm:
+// it reads the current page number and the page-count terminator from the
+// response, and returns the next page number to request. When the current
+// page is the last (>= total) or either value is missing/unparseable,
+// `finished` is true so the loop terminates rather than spinning forever
+// on a response that echoes the same page number back.
+func extractPageNumberNextToken(
+	res response.Response,
+	currentPageElem sdk_internal_dto.HTTPElement,
+	totalPagesElem sdk_internal_dto.HTTPElement,
+) (string, bool) {
+	if currentPageElem == nil || totalPagesElem == nil {
+		return "", true
+	}
+	currStr := extractNextPageToken(res, currentPageElem)
+	totalStr := extractNextPageToken(res, totalPagesElem)
+	curr, currErr := strconv.Atoi(currStr)
+	total, totalErr := strconv.Atoi(totalStr)
+	if currErr != nil || totalErr != nil {
+		return "", true
+	}
+	if curr >= total {
+		return "", true
+	}
+	return strconv.Itoa(curr + 1), false
+}
+
 func page(
 	res response.Response,
 	method anysdk.OperationStore,
@@ -1045,7 +1089,17 @@ func page(
 	if npt == nil || nptRequest == nil {
 		return newPagingState(pageCount, true, nil, nil)
 	}
-	tk := extractNextPageToken(res, npt)
+	var tk string
+	if method.GetPaginationAlgorithm() == anysdk.PaginationAlgorithmPageNumber {
+		terminator := inferPageNumberTerminatorElement(method)
+		next, finished := extractPageNumberNextToken(res, npt, terminator)
+		if finished {
+			return newPagingState(pageCount, true, nil, nil)
+		}
+		tk = next
+	} else {
+		tk = extractNextPageToken(res, npt)
+	}
 	if tk == "" || tk == "<nil>" || tk == "[]" || (rtCtx.HTTPPageLimit > 0 && pageCount >= rtCtx.HTTPPageLimit) {
 		return newPagingState(pageCount, true, nil, nil)
 	}

--- a/public/providerinvokers/anysdkhttp/invoker_test.go
+++ b/public/providerinvokers/anysdkhttp/invoker_test.go
@@ -1,0 +1,101 @@
+package anysdkhttp
+
+import (
+	"net/http"
+	"testing"
+
+	sdk_internal_dto "github.com/stackql/any-sdk/pkg/internaldto"
+	"github.com/stackql/any-sdk/pkg/response"
+
+	"gotest.tools/assert"
+)
+
+func makeBodyResponse(body map[string]interface{}) response.Response {
+	httpResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+	}
+	return response.NewResponse(body, body, httpResp)
+}
+
+// TestExtractPageNumberNextToken_NotLast covers the common case: current page
+// is below the terminator, so the next page (current+1) must be requested.
+func TestExtractPageNumberNextToken_NotLast(t *testing.T) {
+	body := map[string]interface{}{
+		"page":        float64(1),
+		"total_pages": float64(3),
+	}
+	res := makeBodyResponse(body)
+	curr := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.page")
+	total := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.total_pages")
+
+	next, finished := extractPageNumberNextToken(res, curr, total)
+	assert.Equal(t, finished, false)
+	assert.Equal(t, next, "2")
+}
+
+// TestExtractPageNumberNextToken_LastPage covers Cloudflare's actual failure
+// mode from issue #91: when page == total_pages the loop must terminate.
+// Without the page_number algorithm, stackql instead re-requested page=1
+// indefinitely because the response token never went empty.
+func TestExtractPageNumberNextToken_LastPage(t *testing.T) {
+	body := map[string]interface{}{
+		"page":        float64(3),
+		"total_pages": float64(3),
+	}
+	res := makeBodyResponse(body)
+	curr := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.page")
+	total := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.total_pages")
+
+	next, finished := extractPageNumberNextToken(res, curr, total)
+	assert.Equal(t, finished, true)
+	assert.Equal(t, next, "")
+}
+
+// TestExtractPageNumberNextToken_SinglePage covers the single-row Cloudflare
+// case in the issue reproducer (page==1, total_pages==1).
+func TestExtractPageNumberNextToken_SinglePage(t *testing.T) {
+	body := map[string]interface{}{
+		"page":        float64(1),
+		"total_pages": float64(1),
+	}
+	res := makeBodyResponse(body)
+	curr := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.page")
+	total := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.total_pages")
+
+	next, finished := extractPageNumberNextToken(res, curr, total)
+	assert.Equal(t, finished, true)
+	assert.Equal(t, next, "")
+}
+
+// TestExtractPageNumberNextToken_MissingTerminator: if the terminator element
+// is nil (misconfigured yaml) we must terminate rather than loop forever.
+// Strictly safer than today's behaviour.
+func TestExtractPageNumberNextToken_MissingTerminator(t *testing.T) {
+	body := map[string]interface{}{
+		"page":        float64(1),
+		"total_pages": float64(3),
+	}
+	res := makeBodyResponse(body)
+	curr := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.page")
+
+	next, finished := extractPageNumberNextToken(res, curr, nil)
+	assert.Equal(t, finished, true)
+	assert.Equal(t, next, "")
+}
+
+// TestExtractPageNumberNextToken_Unparseable: if either field is missing or
+// non-numeric, we terminate rather than spin.
+func TestExtractPageNumberNextToken_Unparseable(t *testing.T) {
+	body := map[string]interface{}{
+		"page":        "notanumber",
+		"total_pages": float64(3),
+	}
+	res := makeBodyResponse(body)
+	curr := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.page")
+	total := sdk_internal_dto.NewHTTPElement(sdk_internal_dto.BodyAttribute, "$.total_pages")
+
+	next, finished := extractPageNumberNextToken(res, curr, total)
+	assert.Equal(t, finished, true)
+	assert.Equal(t, next, "")
+}


### PR DESCRIPTION
Adds a new `algorithm: page_number` pagination strategy on the pagination block. The loop terminates when the current page number in the response reaches a page-count terminator (the new `responseTerminator` field), rather than waiting for a token to go empty.

This addresses the Cloudflare V4 / Atlassian / ServiceNow class of APIs that signal completion via comparing `result_info.page` to `result_info.total_pages` rather than via an empty next-page token. Closes #91.