### PR TITLE
feat(graphql): pluggable cursor pagination strategies

### DIFF
--- a/internal/anysdk/graphql.go
+++ b/internal/anysdk/graphql.go
@@ -14,13 +14,55 @@ var (
 type GraphQLElement map[string]interface{}
 
 func (gqc GraphQLElement) getJSONPath() (string, bool) {
-	jp, ok := gqc["jsonPath"]
-	switch jp := jp.(type) {
-	case string:
-		return jp, ok
-	default:
+	return gqc.getStringField("jsonPath")
+}
+
+func (gqc GraphQLElement) getStringField(key string) (string, bool) {
+	v, ok := gqc[key]
+	if !ok {
 		return "", false
 	}
+	s, ok := v.(string)
+	if !ok {
+		return "", false
+	}
+	return s, true
+}
+
+// GetCursorStrategy returns the configured cursor.strategy, or "" if absent.
+// Callers should treat "" as the legacy cursor_after default.
+func (gqc GraphQLElement) GetCursorStrategy() (string, bool) {
+	return gqc.getStringField("strategy")
+}
+
+// GetCursorFormat returns the configured cursor.format template, or "" if absent.
+func (gqc GraphQLElement) GetCursorFormat() (string, bool) {
+	return gqc.getStringField("format")
+}
+
+// GetCursorTerminateOnJSONPath returns the configured cursor.terminateOnJsonPath,
+// or "" if absent. Only the page_info strategy consumes this.
+func (gqc GraphQLElement) GetCursorTerminateOnJSONPath() (string, bool) {
+	return gqc.getStringField("terminateOnJsonPath")
+}
+
+// GetCursorPageSize returns the configured cursor.pageSize, or 0 if absent.
+// Only the offset strategy consumes this; non-positive values are treated as
+// "no short-page termination".
+func (gqc GraphQLElement) GetCursorPageSize() (int, bool) {
+	v, ok := gqc["pageSize"]
+	if !ok {
+		return 0, false
+	}
+	switch n := v.(type) {
+	case int:
+		return n, true
+	case int64:
+		return int(n), true
+	case float64:
+		return int(n), true
+	}
+	return 0, false
 }
 
 type GraphQL interface {
@@ -33,6 +75,10 @@ type GraphQL interface {
 	GetHTTPVerb() string
 	GetCursor() GraphQLElement
 	GetResponseSelection() GraphQLElement
+	GetCursorStrategy() (string, bool)
+	GetCursorFormat() (string, bool)
+	GetCursorTerminateOnJSONPath() (string, bool)
+	GetCursorPageSize() (int, bool)
 }
 
 type standardGraphQL struct {
@@ -97,4 +143,32 @@ func (gq *standardGraphQL) GetCursor() GraphQLElement {
 
 func (gq *standardGraphQL) GetResponseSelection() GraphQLElement {
 	return gq.ReponseSelection
+}
+
+func (gq *standardGraphQL) GetCursorStrategy() (string, bool) {
+	if gq.Cursor == nil {
+		return "", false
+	}
+	return gq.Cursor.GetCursorStrategy()
+}
+
+func (gq *standardGraphQL) GetCursorFormat() (string, bool) {
+	if gq.Cursor == nil {
+		return "", false
+	}
+	return gq.Cursor.GetCursorFormat()
+}
+
+func (gq *standardGraphQL) GetCursorTerminateOnJSONPath() (string, bool) {
+	if gq.Cursor == nil {
+		return "", false
+	}
+	return gq.Cursor.GetCursorTerminateOnJSONPath()
+}
+
+func (gq *standardGraphQL) GetCursorPageSize() (int, bool) {
+	if gq.Cursor == nil {
+		return 0, false
+	}
+	return gq.Cursor.GetCursorPageSize()
 }

--- a/pkg/graphql/graphql.go
+++ b/pkg/graphql/graphql.go
@@ -19,6 +19,60 @@ var (
 	_ template.ExecError = template.ExecError{}
 )
 
+// CursorStrategy enumerates the pluggable pagination shapes supported by
+// StandardGQLReader. The empty string is treated as CursorStrategyAfter to
+// preserve back-compat with specs that predate this field.
+type CursorStrategy string
+
+const (
+	// CursorStrategyAfter is the default Relay-style ", after: \"<value>\""
+	// cursor splice. Termination is signalled by an empty/non-scalar cursor.
+	CursorStrategyAfter CursorStrategy = "cursor_after"
+	// CursorStrategyKeyset injects a filter comparator (typically "_gt") on
+	// the last row's sort key. Used by Cloudflare GraphQL Analytics and
+	// similar APIs that do not support cursors. Termination is signalled by
+	// an empty response row array.
+	CursorStrategyKeyset CursorStrategy = "keyset"
+	// CursorStrategyOffset synthesises a running row count client-side and
+	// substitutes it as ", offset: <count>". Termination is signalled by an
+	// empty response row array (or a short page if PageSize is configured).
+	CursorStrategyOffset CursorStrategy = "offset"
+	// CursorStrategyPageInfo reads ", after: \"<endCursor>\"" from a
+	// jsonpath but terminates on a separate boolean termination flag
+	// (typically `pageInfo.hasNextPage`) — required for Relay-strict
+	// endpoints where the cursor remains non-empty on the final page.
+	CursorStrategyPageInfo CursorStrategy = "page_info"
+)
+
+// CursorConfig configures a pagination strategy for StandardGQLReader. An
+// empty Strategy defaults to CursorStrategyAfter, which is byte-identical to
+// the pre-strategy behaviour.
+type CursorConfig struct {
+	// Strategy selects the pagination shape. Empty == CursorStrategyAfter.
+	Strategy CursorStrategy
+	// JSONPath is the value-source path for the cursor. Required for
+	// cursor_after, keyset, and page_info; ignored for offset.
+	JSONPath string
+	// FormatTemplate is an optional Go text/template rendered into
+	// iterativeInput["cursor"] each iteration. Bindings depend on strategy:
+	//   - cursor_after / offset / page_info: {{ .value }}
+	//   - keyset:                            {{ .value }} when the JSON path
+	//                                        resolves to a scalar; the
+	//                                        object's fields by name when it
+	//                                        resolves to a map
+	// When empty, strategy-specific defaults apply (see strategy docs).
+	FormatTemplate string
+	// TerminateOnJSONPath is the jsonpath inspected for a termination flag
+	// after each page. Only used by CursorStrategyPageInfo.
+	TerminateOnJSONPath string
+	// PageSize, when > 0, terminates CursorStrategyOffset early when a page
+	// returns fewer rows than this value. Ignored by other strategies.
+	PageSize int
+}
+
+// NewStandardGQLReader constructs a StandardGQLReader with the default
+// CursorStrategyAfter strategy. Behaviour is identical to the pre-strategy
+// reader.
 func NewStandardGQLReader(
 	anySdkClient client.AnySdkClient,
 	request *http.Request,
@@ -29,7 +83,7 @@ func NewStandardGQLReader(
 	responseJsonPath string,
 	latestCursorJsonPath string,
 ) (GQLReader, error) {
-	return NewStandardGQLReaderWithTransform(
+	return NewStandardGQLReaderFull(
 		anySdkClient,
 		request,
 		httpPageLimit,
@@ -37,7 +91,7 @@ func NewStandardGQLReader(
 		constInput,
 		initialCursor,
 		responseJsonPath,
-		latestCursorJsonPath,
+		CursorConfig{Strategy: CursorStrategyAfter, JSONPath: latestCursorJsonPath},
 		"",
 		"",
 	)
@@ -59,23 +113,92 @@ func NewStandardGQLReaderWithTransform(
 	transformType string,
 	transformBody string,
 ) (GQLReader, error) {
+	return NewStandardGQLReaderFull(
+		anySdkClient,
+		request,
+		httpPageLimit,
+		baseQuery,
+		constInput,
+		initialCursor,
+		responseJsonPath,
+		CursorConfig{Strategy: CursorStrategyAfter, JSONPath: latestCursorJsonPath},
+		transformType,
+		transformBody,
+	)
+}
+
+// NewStandardGQLReaderWithCursor constructs a StandardGQLReader using the
+// supplied CursorConfig. Supplying CursorConfig{} (Strategy == "") yields the
+// default cursor_after behaviour.
+func NewStandardGQLReaderWithCursor(
+	anySdkClient client.AnySdkClient,
+	request *http.Request,
+	httpPageLimit int,
+	baseQuery string,
+	constInput map[string]interface{},
+	initialCursor string,
+	responseJsonPath string,
+	cursor CursorConfig,
+) (GQLReader, error) {
+	return NewStandardGQLReaderFull(
+		anySdkClient,
+		request,
+		httpPageLimit,
+		baseQuery,
+		constInput,
+		initialCursor,
+		responseJsonPath,
+		cursor,
+		"",
+		"",
+	)
+}
+
+// NewStandardGQLReaderFull is the most general constructor; the narrower
+// constructors are thin wrappers around it.
+func NewStandardGQLReaderFull(
+	anySdkClient client.AnySdkClient,
+	request *http.Request,
+	httpPageLimit int,
+	baseQuery string,
+	constInput map[string]interface{},
+	initialCursor string,
+	responseJsonPath string,
+	cursor CursorConfig,
+	transformType string,
+	transformBody string,
+) (GQLReader, error) {
 	tmpl, err := template.New("gqlTmpl").Parse(baseQuery)
 	if err != nil {
 		return nil, err
 	}
+	if cursor.Strategy == "" {
+		cursor.Strategy = CursorStrategyAfter
+	}
+	if err := validateCursorConfig(cursor); err != nil {
+		return nil, err
+	}
+	var cursorTmpl *template.Template
+	if cursor.FormatTemplate != "" {
+		cursorTmpl, err = template.New("gqlCursorTmpl").Parse(cursor.FormatTemplate)
+		if err != nil {
+			return nil, fmt.Errorf("invalid cursor.format template: %w", err)
+		}
+	}
 	rv := &StandardGQLReader{
-		anySdkClient:         anySdkClient,
-		baseQuery:            baseQuery,
-		httpPageLimit:        httpPageLimit,
-		constInput:           constInput,
-		latestCursorJsonPath: latestCursorJsonPath,
-		responseJsonPath:     responseJsonPath,
-		queryTemplate:        tmpl,
-		request:              request,
-		pageCount:            1,
-		iterativeInput:       make(map[string]interface{}),
-		transformType:        transformType,
-		transformBody:        transformBody,
+		anySdkClient:     anySdkClient,
+		baseQuery:        baseQuery,
+		httpPageLimit:    httpPageLimit,
+		constInput:       constInput,
+		responseJsonPath: responseJsonPath,
+		queryTemplate:    tmpl,
+		request:          request,
+		pageCount:        1,
+		iterativeInput:   make(map[string]interface{}),
+		transformType:    transformType,
+		transformBody:    transformBody,
+		cursorConfig:     cursor,
+		cursorTemplate:   cursorTmpl,
 	}
 	for k, v := range constInput {
 		rv.iterativeInput[k] = v
@@ -84,19 +207,37 @@ func NewStandardGQLReaderWithTransform(
 	return rv, nil
 }
 
+func validateCursorConfig(c CursorConfig) error {
+	switch c.Strategy {
+	case CursorStrategyAfter, CursorStrategyKeyset, CursorStrategyOffset, CursorStrategyPageInfo:
+		// known
+	default:
+		return fmt.Errorf("unknown cursor strategy: %q", c.Strategy)
+	}
+	if c.Strategy == CursorStrategyKeyset && c.FormatTemplate == "" {
+		return fmt.Errorf("cursor strategy %q requires cursor.format template", c.Strategy)
+	}
+	if c.Strategy == CursorStrategyPageInfo && c.TerminateOnJSONPath == "" {
+		return fmt.Errorf("cursor strategy %q requires cursor.terminateOnJsonPath", c.Strategy)
+	}
+	return nil
+}
+
 type StandardGQLReader struct {
-	baseQuery            string
-	constInput           map[string]interface{}
-	iterativeInput       map[string]interface{}
-	anySdkClient         client.AnySdkClient
-	httpPageLimit        int
-	queryTemplate        *template.Template
-	responseJsonPath     string
-	latestCursorJsonPath string
-	request              *http.Request
-	pageCount            int
-	transformType        string
-	transformBody        string
+	baseQuery        string
+	constInput       map[string]interface{}
+	iterativeInput   map[string]interface{}
+	anySdkClient     client.AnySdkClient
+	httpPageLimit    int
+	queryTemplate    *template.Template
+	responseJsonPath string
+	request          *http.Request
+	pageCount        int
+	transformType    string
+	transformBody    string
+	cursorConfig     CursorConfig
+	cursorTemplate   *template.Template
+	rowsReturned     int
 }
 
 type anySdkGraphQLHTTPDesignation struct {
@@ -184,33 +325,13 @@ func (gq *StandardGQLReader) Read() ([]map[string]interface{}, error) {
 	if len(target) == 0 {
 		returnErr = io.EOF
 	}
-	cursorRaw, err := jsonpath.Get(gq.latestCursorJsonPath, target)
-	if err != nil {
-		returnErr = io.EOF
-	} else {
-		switch ct := cursorRaw.(type) {
-		case []interface{}:
-			if len(ct) == 1 {
-				switch c := ct[0].(type) {
-				case string:
-					gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: "%s"`, c)
-				default:
-					gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: %v`, c)
-				}
-			} else {
-				returnErr = io.EOF
-			}
-		default:
-			returnErr = io.EOF
-		}
-	}
 	processedResponse, err := jsonpath.Get(gq.responseJsonPath, target)
 	if err != nil {
 		return nil, err
 	}
+	var rv []map[string]interface{}
 	switch pr := processedResponse.(type) {
 	case []interface{}:
-		var rv []map[string]interface{}
 		for _, v := range pr {
 			switch v := v.(type) {
 			case map[string]interface{}:
@@ -219,10 +340,207 @@ func (gq *StandardGQLReader) Read() ([]map[string]interface{}, error) {
 				return nil, fmt.Errorf("cannot accomodate GraphQL pocessed response item of type = '%T'", v)
 			}
 		}
-		return rv, returnErr
 	default:
 		return nil, fmt.Errorf("cannot accomodate GraphQL pocessed response of type = '%T'", pr)
 	}
+	gq.rowsReturned += len(rv)
+	if returnErr == nil {
+		if cursorErr := gq.advanceCursor(target, len(rv)); cursorErr != nil {
+			returnErr = cursorErr
+		}
+	}
+	return rv, returnErr
+}
+
+// advanceCursor dispatches to the per-strategy helper. It either updates
+// gq.iterativeInput["cursor"] for the next page, returns io.EOF to terminate
+// iteration, or returns a non-EOF error to abort with a hard failure.
+func (gq *StandardGQLReader) advanceCursor(target map[string]interface{}, rowCount int) error {
+	switch gq.cursorConfig.Strategy {
+	case CursorStrategyAfter:
+		return gq.advanceCursorAfter(target)
+	case CursorStrategyKeyset:
+		return gq.advanceKeyset(target, rowCount)
+	case CursorStrategyOffset:
+		return gq.advanceOffset(rowCount)
+	case CursorStrategyPageInfo:
+		return gq.advancePageInfo(target)
+	}
+	return fmt.Errorf("unknown cursor strategy: %q", gq.cursorConfig.Strategy)
+}
+
+func (gq *StandardGQLReader) advanceCursorAfter(target map[string]interface{}) error {
+	cursorRaw, err := jsonpath.Get(gq.cursorConfig.JSONPath, target)
+	if err != nil {
+		return io.EOF
+	}
+	ct, ok := cursorRaw.([]interface{})
+	if !ok || len(ct) != 1 {
+		return io.EOF
+	}
+	if gq.cursorTemplate != nil {
+		rendered, rerr := gq.renderCursorTemplate(map[string]interface{}{"value": ct[0]})
+		if rerr != nil {
+			return rerr
+		}
+		gq.iterativeInput["cursor"] = rendered
+		return nil
+	}
+	switch c := ct[0].(type) {
+	case string:
+		gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: "%s"`, c)
+	default:
+		gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: %v`, c)
+	}
+	return nil
+}
+
+func (gq *StandardGQLReader) advanceKeyset(target map[string]interface{}, rowCount int) error {
+	if rowCount == 0 {
+		return io.EOF
+	}
+	cursorRaw, err := jsonpath.Get(gq.cursorConfig.JSONPath, target)
+	if err != nil {
+		return io.EOF
+	}
+	tmplCtx, ok := keysetTemplateContext(cursorRaw)
+	if !ok {
+		return io.EOF
+	}
+	rendered, err := gq.renderCursorTemplate(tmplCtx)
+	if err != nil {
+		return err
+	}
+	gq.iterativeInput["cursor"] = rendered
+	return nil
+}
+
+// keysetTemplateContext turns a jsonpath result into the template binding map
+// used by the keyset format template. It supports three shapes:
+//   - scalar value             -> {"value": <v>}
+//   - map of field-name->value -> field names + a "value" alias for single-field maps
+//   - 1-element slice wrapping either of the above (the common JSONPath slice form)
+func keysetTemplateContext(raw interface{}) (map[string]interface{}, bool) {
+	switch v := raw.(type) {
+	case []interface{}:
+		if len(v) == 0 {
+			return nil, false
+		}
+		return keysetTemplateContext(v[0])
+	case map[string]interface{}:
+		if len(v) == 0 {
+			return nil, false
+		}
+		ctx := make(map[string]interface{}, len(v)+1)
+		for k, vv := range v {
+			ctx[k] = vv
+		}
+		if len(v) == 1 {
+			for _, vv := range v {
+				ctx["value"] = vv
+			}
+		}
+		return ctx, true
+	default:
+		return map[string]interface{}{"value": v}, true
+	}
+}
+
+func (gq *StandardGQLReader) advanceOffset(rowCount int) error {
+	if rowCount == 0 {
+		return io.EOF
+	}
+	if gq.cursorConfig.PageSize > 0 && rowCount < gq.cursorConfig.PageSize {
+		return io.EOF
+	}
+	tmplCtx := map[string]interface{}{"value": gq.rowsReturned}
+	if gq.cursorTemplate != nil {
+		rendered, err := gq.renderCursorTemplate(tmplCtx)
+		if err != nil {
+			return err
+		}
+		gq.iterativeInput["cursor"] = rendered
+		return nil
+	}
+	gq.iterativeInput["cursor"] = fmt.Sprintf(`, offset: %d`, gq.rowsReturned)
+	return nil
+}
+
+func (gq *StandardGQLReader) advancePageInfo(target map[string]interface{}) error {
+	hasNext, err := jsonpath.Get(gq.cursorConfig.TerminateOnJSONPath, target)
+	if err != nil {
+		return io.EOF
+	}
+	if !isPageInfoContinue(hasNext) {
+		return io.EOF
+	}
+	cursorRaw, err := jsonpath.Get(gq.cursorConfig.JSONPath, target)
+	if err != nil {
+		return io.EOF
+	}
+	val, ok := scalarFromJSONPath(cursorRaw)
+	if !ok {
+		return io.EOF
+	}
+	if gq.cursorTemplate != nil {
+		rendered, rerr := gq.renderCursorTemplate(map[string]interface{}{"value": val})
+		if rerr != nil {
+			return rerr
+		}
+		gq.iterativeInput["cursor"] = rendered
+		return nil
+	}
+	switch c := val.(type) {
+	case string:
+		gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: "%s"`, c)
+	default:
+		gq.iterativeInput["cursor"] = fmt.Sprintf(`, after: %v`, c)
+	}
+	return nil
+}
+
+// isPageInfoContinue interprets the value at TerminateOnJSONPath. A boolean
+// false or a nil value means terminate; anything else (including unwrapping
+// a 1-element slice) means continue. Treating "absent" as terminate is the
+// conservative choice — if the spec writer pointed us at a flag they expected
+// to flip, we'd rather stop than spin forever.
+func isPageInfoContinue(v interface{}) bool {
+	switch t := v.(type) {
+	case []interface{}:
+		if len(t) == 0 {
+			return false
+		}
+		return isPageInfoContinue(t[0])
+	case bool:
+		return t
+	case nil:
+		return false
+	default:
+		return true
+	}
+}
+
+// scalarFromJSONPath extracts a single scalar value from a jsonpath result,
+// transparently unwrapping the 1-element slice form that arises from
+// last-row selectors like `[-1:].field`.
+func scalarFromJSONPath(v interface{}) (interface{}, bool) {
+	switch t := v.(type) {
+	case []interface{}:
+		if len(t) != 1 {
+			return nil, false
+		}
+		return t[0], true
+	default:
+		return v, true
+	}
+}
+
+func (gq *StandardGQLReader) renderCursorTemplate(ctx map[string]interface{}) (string, error) {
+	var buf bytes.Buffer
+	if err := gq.cursorTemplate.Execute(&buf, ctx); err != nil {
+		return "", fmt.Errorf("failed to render cursor.format template: %w", err)
+	}
+	return buf.String(), nil
 }
 
 func (gq *StandardGQLReader) applyResponseTransform(target map[string]interface{}) (map[string]interface{}, error) {

--- a/pkg/graphql/graphql_test.go
+++ b/pkg/graphql/graphql_test.go
@@ -33,6 +33,39 @@ func (f *fakeAnySdkClient) Do(client.AnySdkDesignation, client.AnySdkArgList) (c
 	return &fakeAnySdkResponse{resp: resp}, nil
 }
 
+// multiPageAnySdkClient walks through a sequence of response bodies, one per
+// Do() call. After the sequence is exhausted, the last body is repeated.
+type multiPageAnySdkClient struct {
+	bodies   []string
+	call     int
+	captured []string
+}
+
+func (f *multiPageAnySdkClient) Do(_ client.AnySdkDesignation, args client.AnySdkArgList) (client.AnySdkResponse, error) {
+	// Record the rendered request body so tests can assert on cursor splicing.
+	for _, a := range args.GetArgs() {
+		v, ok := a.GetArg()
+		if !ok {
+			continue
+		}
+		if req, ok := v.(*http.Request); ok && req.Body != nil {
+			b, _ := io.ReadAll(req.Body)
+			f.captured = append(f.captured, string(b))
+		}
+	}
+	idx := f.call
+	if idx >= len(f.bodies) {
+		idx = len(f.bodies) - 1
+	}
+	f.call++
+	resp := &http.Response{
+		StatusCode: 200,
+		Body:       io.NopCloser(bytes.NewBufferString(f.bodies[idx])),
+		Header:     http.Header{},
+	}
+	return &fakeAnySdkResponse{resp: resp}, nil
+}
+
 // cloudflareLikeBody is a minimal fixture mimicking the nested shape of a Cloudflare
 // GraphQL Analytics httpRequestsAdaptiveGroups response: one row under
 // data.viewer.zones[0].httpRequestsAdaptiveGroups with dimensions{}, sum{}, count.
@@ -208,5 +241,266 @@ func TestRead_UnsupportedTransformType(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported response.transform type") {
 		t.Errorf("expected unsupported-transform error, got: %v", err)
+	}
+}
+
+// readerCursor exposes the iterativeInput["cursor"] slice for assertions in
+// tests that drive multiple iterations of Read().
+func readerCursor(t *testing.T, r GQLReader) interface{} {
+	t.Helper()
+	sg, ok := r.(*StandardGQLReader)
+	if !ok {
+		t.Fatalf("reader is not *StandardGQLReader; got %T", r)
+	}
+	return sg.iterativeInput["cursor"]
+}
+
+// keysetBody renders a Cloudflare-shaped two-row response with a configurable
+// "last row" datetime, so we can chain page bodies in a multi-page test.
+func keysetBody(lastDatetime string) string {
+	if lastDatetime == "" {
+		return `{"data":{"viewer":{"zones":[{"httpRequestsAdaptiveGroups":[]}]}}}`
+	}
+	return `{"data":{"viewer":{"zones":[{"httpRequestsAdaptiveGroups":[
+  {"dimensions":{"datetime":"2026-05-28T10:00:00Z","clientCountryName":"US"},"sum":{"requests":42}},
+  {"dimensions":{"datetime":"` + lastDatetime + `","clientCountryName":"GB"},"sum":{"requests":17}}
+]}]}}}`
+}
+
+// TestRead_Keyset verifies that the keyset strategy splices a comparator-style
+// cursor built from the last row's sort key into the next request, and that
+// an empty response array terminates the iteration with io.EOF.
+func TestRead_Keyset(t *testing.T) {
+	c := &multiPageAnySdkClient{
+		bodies: []string{
+			keysetBody("2026-05-28T10:01:00Z"),
+			keysetBody(""), // empty page → terminate
+		},
+	}
+	req := newTestRequest(t)
+	r, err := NewStandardGQLReaderWithCursor(
+		c,
+		req,
+		0,
+		`query { zone(filter: { datetime_geq: "x"{{ .cursor }} }) { d } }`,
+		map[string]interface{}{},
+		"",
+		"$.data.viewer.zones[0].httpRequestsAdaptiveGroups[*]",
+		CursorConfig{
+			Strategy:       CursorStrategyKeyset,
+			JSONPath:       "$.data.viewer.zones[0].httpRequestsAdaptiveGroups[-1:].dimensions.datetime",
+			FormatTemplate: `, AND datetime_gt: "{{ .value }}"`,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewStandardGQLReaderWithCursor: %v", err)
+	}
+	rows1, err := r.Read()
+	if err != nil {
+		t.Fatalf("page 1: unexpected error: %v", err)
+	}
+	if len(rows1) != 2 {
+		t.Fatalf("page 1: expected 2 rows, got %d", len(rows1))
+	}
+	if got, want := readerCursor(t, r), `, AND datetime_gt: "2026-05-28T10:01:00Z"`; got != want {
+		t.Errorf("page 1 cursor: got %q, want %q", got, want)
+	}
+	rows2, err := r.Read()
+	if err != io.EOF {
+		t.Errorf("page 2: expected io.EOF, got %v", err)
+	}
+	if len(rows2) != 0 {
+		t.Errorf("page 2: expected 0 rows on empty page, got %d", len(rows2))
+	}
+	if len(c.captured) < 2 {
+		t.Fatalf("expected at least 2 captured requests, got %d", len(c.captured))
+	}
+	if !strings.Contains(c.captured[1], `AND datetime_gt: \"2026-05-28T10:01:00Z\"`) {
+		t.Errorf("page 2 request did not contain the keyset splice; body=%q", c.captured[1])
+	}
+}
+
+// offsetBody returns a response carrying n synthetic rows under $.data.items.
+func offsetBody(n int) string {
+	parts := make([]string, 0, n)
+	for i := 0; i < n; i++ {
+		parts = append(parts, `{"id":`+itoa(i)+`}`)
+	}
+	return `{"data":{"items":[` + strings.Join(parts, ",") + `]}}`
+}
+
+func itoa(i int) string {
+	// Avoid pulling strconv into the test imports for a single use.
+	if i == 0 {
+		return "0"
+	}
+	neg := false
+	if i < 0 {
+		neg = true
+		i = -i
+	}
+	var digits []byte
+	for i > 0 {
+		digits = append([]byte{byte('0' + i%10)}, digits...)
+		i /= 10
+	}
+	if neg {
+		return "-" + string(digits)
+	}
+	return string(digits)
+}
+
+// TestRead_Offset verifies that the offset strategy substitutes a running row
+// count as ", offset: N" each page and terminates when a short page returns
+// fewer rows than the configured PageSize.
+func TestRead_Offset(t *testing.T) {
+	const pageSize = 50
+	c := &multiPageAnySdkClient{
+		bodies: []string{
+			offsetBody(pageSize), // page 1: 50 rows
+			offsetBody(pageSize), // page 2: 50 rows
+			offsetBody(23),       // page 3: 23 rows → short page → terminate after this
+		},
+	}
+	req := newTestRequest(t)
+	r, err := NewStandardGQLReaderWithCursor(
+		c,
+		req,
+		0,
+		`query { items(limit: 50{{ .cursor }}) { id } }`,
+		map[string]interface{}{},
+		"",
+		"$.data.items[*]",
+		CursorConfig{
+			Strategy: CursorStrategyOffset,
+			PageSize: pageSize,
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewStandardGQLReaderWithCursor: %v", err)
+	}
+	rows1, err := r.Read()
+	if err != nil {
+		t.Fatalf("page 1: unexpected error: %v", err)
+	}
+	if len(rows1) != pageSize {
+		t.Fatalf("page 1: expected %d rows, got %d", pageSize, len(rows1))
+	}
+	if got, want := readerCursor(t, r), `, offset: 50`; got != want {
+		t.Errorf("page 1 cursor: got %q, want %q", got, want)
+	}
+	rows2, err := r.Read()
+	if err != nil {
+		t.Fatalf("page 2: unexpected error: %v", err)
+	}
+	if len(rows2) != pageSize {
+		t.Fatalf("page 2: expected %d rows, got %d", pageSize, len(rows2))
+	}
+	if got, want := readerCursor(t, r), `, offset: 100`; got != want {
+		t.Errorf("page 2 cursor: got %q, want %q", got, want)
+	}
+	rows3, err := r.Read()
+	if err != io.EOF {
+		t.Errorf("page 3: expected io.EOF after short page, got %v", err)
+	}
+	if len(rows3) != 23 {
+		t.Errorf("page 3: expected 23 rows, got %d", len(rows3))
+	}
+}
+
+// pageInfoBody renders a minimal Relay-style search response with a pageInfo
+// block driving termination.
+func pageInfoBody(endCursor string, hasNextPage bool) string {
+	hnp := "false"
+	if hasNextPage {
+		hnp = "true"
+	}
+	return `{"data":{"search":{"nodes":[{"id":"n1"}],"pageInfo":{"endCursor":"` + endCursor + `","hasNextPage":` + hnp + `}}}}`
+}
+
+// TestRead_PageInfo verifies that the page_info strategy uses endCursor for
+// the splice and pageInfo.hasNextPage for termination — including the case
+// where the final page still carries a non-empty endCursor but hasNextPage
+// is false (the Relay-strict signal we cannot detect with cursor_after).
+func TestRead_PageInfo(t *testing.T) {
+	c := &multiPageAnySdkClient{
+		bodies: []string{
+			pageInfoBody("Y3Vyc29yOjI=", true),
+			pageInfoBody("Y3Vyc29yOjQ=", false), // hasNextPage=false → terminate even though endCursor is set
+		},
+	}
+	req := newTestRequest(t)
+	r, err := NewStandardGQLReaderWithCursor(
+		c,
+		req,
+		0,
+		`query { search(first: 10{{ .cursor }}) { nodes { id } } }`,
+		map[string]interface{}{},
+		"",
+		"$.data.search.nodes[*]",
+		CursorConfig{
+			Strategy:            CursorStrategyPageInfo,
+			JSONPath:            "$.data.search.pageInfo.endCursor",
+			TerminateOnJSONPath: "$.data.search.pageInfo.hasNextPage",
+		},
+	)
+	if err != nil {
+		t.Fatalf("NewStandardGQLReaderWithCursor: %v", err)
+	}
+	if _, err := r.Read(); err != nil {
+		t.Fatalf("page 1: unexpected error: %v", err)
+	}
+	if got, want := readerCursor(t, r), `, after: "Y3Vyc29yOjI="`; got != want {
+		t.Errorf("page 1 cursor: got %q, want %q", got, want)
+	}
+	_, err = r.Read()
+	if err != io.EOF {
+		t.Errorf("page 2: expected io.EOF (hasNextPage=false), got %v", err)
+	}
+}
+
+// TestNewStandardGQLReaderWithCursor_UnknownStrategy ensures construction
+// fails fast on an unrecognised strategy rather than silently defaulting.
+func TestNewStandardGQLReaderWithCursor_UnknownStrategy(t *testing.T) {
+	c := &fakeAnySdkClient{bodyJSON: `{}`}
+	req := newTestRequest(t)
+	_, err := NewStandardGQLReaderWithCursor(
+		c,
+		req,
+		0,
+		`{}`,
+		map[string]interface{}{},
+		"",
+		"$.data[*]",
+		CursorConfig{Strategy: "bogus"},
+	)
+	if err == nil {
+		t.Fatalf("expected error for unknown cursor strategy, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown cursor strategy") {
+		t.Errorf("expected unknown-strategy error, got: %v", err)
+	}
+}
+
+// TestNewStandardGQLReaderWithCursor_KeysetRequiresFormat ensures a keyset
+// configuration without a format template is rejected at construction time.
+func TestNewStandardGQLReaderWithCursor_KeysetRequiresFormat(t *testing.T) {
+	c := &fakeAnySdkClient{bodyJSON: `{}`}
+	req := newTestRequest(t)
+	_, err := NewStandardGQLReaderWithCursor(
+		c,
+		req,
+		0,
+		`{}`,
+		map[string]interface{}{},
+		"",
+		"$.data[*]",
+		CursorConfig{Strategy: CursorStrategyKeyset, JSONPath: "$.x"},
+	)
+	if err == nil {
+		t.Fatalf("expected error for keyset without format, got nil")
+	}
+	if !strings.Contains(err.Error(), "format") {
+		t.Errorf("expected format-required error, got: %v", err)
 	}
 }

--- a/public/formulation/interfaces.go
+++ b/public/formulation/interfaces.go
@@ -79,6 +79,10 @@ type GraphQL interface {
 	GetCursorJSONPath() (string, bool)
 	GetQuery() string
 	GetResponseJSONPath() (string, bool)
+	GetCursorStrategy() (string, bool)
+	GetCursorFormat() (string, bool)
+	GetCursorTerminateOnJSONPath() (string, bool)
+	GetCursorPageSize() (int, bool)
 	IsEmpty() bool
 	unwrap() anysdk.GraphQL
 }

--- a/public/formulation/wrappers.go
+++ b/public/formulation/wrappers.go
@@ -515,6 +515,22 @@ func (w *wrappedGraphQL) GetResponseJSONPath() (string, bool) {
 	return r0, r1
 }
 
+func (w *wrappedGraphQL) GetCursorStrategy() (string, bool) {
+	return w.inner.GetCursorStrategy()
+}
+
+func (w *wrappedGraphQL) GetCursorFormat() (string, bool) {
+	return w.inner.GetCursorFormat()
+}
+
+func (w *wrappedGraphQL) GetCursorTerminateOnJSONPath() (string, bool) {
+	return w.inner.GetCursorTerminateOnJSONPath()
+}
+
+func (w *wrappedGraphQL) GetCursorPageSize() (int, bool) {
+	return w.inner.GetCursorPageSize()
+}
+
 func (w *wrappedGraphQL) unwrap() anysdk.GraphQL {
 	return w.inner
 }


### PR DESCRIPTION
Adds CursorStrategy / CursorConfig and a NewStandardGQLReaderWithCursor constructor that lets the GraphQL acquire path select one of four pagination shapes at construction time:

- cursor_after (default; byte-identical to prior behaviour)
- keyset       (Cloudflare-style filter-comparator splice)
- offset       (Hasura-style client-synthesised offset)
- page_info    (Relay-strict, terminates on pageInfo.hasNextPage=false)

The legacy two-arg cursor block (jsonPath only) continues to parse as cursor_after. New cursor block keys (strategy / format / terminateOnJsonPath / pageSize) flow in through the existing GraphQLElement map and are surfaced via new accessor methods on anysdk.GraphQL and the formulation wrapper, so downstream callers in stackql can pass a fully-populated CursorConfig through to the reader without depending on internal anysdk types.

Refs #96