### PR TITLE
feat(formulation): expose GetPaginationAlgorithm and GetPaginationResponseTerminatorTokenSemantic on OperationStore

### DIFF
--- a/public/formulation/interfaces.go
+++ b/public/formulation/interfaces.go
@@ -199,8 +199,10 @@ type OperationStore interface {
 	DeprecatedProcessResponse(response *http.Response) (map[string]interface{}, error)
 	GetName() string
 	GetNonBodyParameters() map[string]Addressable
+	GetPaginationAlgorithm() string
 	GetPaginationRequestTokenSemantic() (TokenSemantic, bool)
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
+	GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	GetParameter(paramKey string) (Addressable, bool)
 	GetRequestBodySchema() (Schema, error)
 	GetRequiredNonBodyParameters() map[string]Addressable

--- a/public/formulation/wrappers.go
+++ b/public/formulation/wrappers.go
@@ -874,6 +874,11 @@ func (w *wrappedOperationStore) GetNonBodyParameters() map[string]Addressable {
 	return wrapMapString_Addressable(r0)
 }
 
+func (w *wrappedOperationStore) GetPaginationAlgorithm() string {
+	r0 := w.inner.GetPaginationAlgorithm()
+	return r0
+}
+
 func (w *wrappedOperationStore) GetPaginationRequestTokenSemantic() (TokenSemantic, bool) {
 	r0, r1 := w.inner.GetPaginationRequestTokenSemantic()
 	return &wrappedTokenSemantic{inner: r0}, r1
@@ -881,6 +886,11 @@ func (w *wrappedOperationStore) GetPaginationRequestTokenSemantic() (TokenSemant
 
 func (w *wrappedOperationStore) GetPaginationResponseTokenSemantic() (TokenSemantic, bool) {
 	r0, r1 := w.inner.GetPaginationResponseTokenSemantic()
+	return &wrappedTokenSemantic{inner: r0}, r1
+}
+
+func (w *wrappedOperationStore) GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	r0, r1 := w.inner.GetPaginationResponseTerminatorTokenSemantic()
 	return &wrappedTokenSemantic{inner: r0}, r1
 }
 
@@ -1536,6 +1546,11 @@ func (w *wrappedStandardOperationStore) GetNonBodyParameters() map[string]Addres
 	return wrapMapString_Addressable(r0)
 }
 
+func (w *wrappedStandardOperationStore) GetPaginationAlgorithm() string {
+	r0 := w.inner.GetPaginationAlgorithm()
+	return r0
+}
+
 func (w *wrappedStandardOperationStore) GetPaginationRequestTokenSemantic() (TokenSemantic, bool) {
 	r0, r1 := w.inner.GetPaginationRequestTokenSemantic()
 	return &wrappedTokenSemantic{inner: r0}, r1
@@ -1543,6 +1558,11 @@ func (w *wrappedStandardOperationStore) GetPaginationRequestTokenSemantic() (Tok
 
 func (w *wrappedStandardOperationStore) GetPaginationResponseTokenSemantic() (TokenSemantic, bool) {
 	r0, r1 := w.inner.GetPaginationResponseTokenSemantic()
+	return &wrappedTokenSemantic{inner: r0}, r1
+}
+
+func (w *wrappedStandardOperationStore) GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool) {
+	r0, r1 := w.inner.GetPaginationResponseTerminatorTokenSemantic()
 	return &wrappedTokenSemantic{inner: r0}, r1
 }
 


### PR DESCRIPTION
Lifts the two existing methods on the internal OperationStore through public/formulation so that out-of-tree consumers (notably stackql's SELECT pagination loop in mono_valent_execution.page) can dispatch on the algorithm and read the responseTerminator token semantic without going through anysdkhttp.Invoke. Required to wire the page_number paginator added in v0.5.3-alpha05 from stackql.

Both wrappedOperationStore and wrappedStandardOperationStore receive the new methods so the StandardOperationStore embedding contract is satisfied. Behaviour inside any-sdk is unchanged.

Closes #99