### PR TITLE
fix(casing) + feat(schema): wire-name extraction (#108), snake param resolution + GET assembly (#109), provider config JSON Schema (#110)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# CLAUDE.md
+
+Coding guidelines and conventions for working in `any-sdk`. Read these before making changes.
+
+For domain context (what an `any-sdk` provider document is, the provider/service/resource/method hierarchy, SQL-verb mapping, validation) see @AGENTS.md. This file is about *how to write the Go code*.
+
+## Architecture and where code goes
+
+Three layers, with a strict separation of concerns:
+
+- `internal/anysdk/` - the real implementation. All logic lives here. Foreign-system semantics (OData `$filter` syntax, AWS XML envelope shapes, pagination dialects, casing rules, etc.) belong here, never in a downstream consumer such as `stackql`.
+- `pkg/` - shared, dependency-light libraries (e.g. `pkg/casing`, `pkg/stream_transform`). A `pkg/` package must not import `internal/anysdk` (that is an import cycle). If such a package needs a type from internal, define a minimal neutral interface in the `pkg/` package and have the caller adapt to it.
+- `public/formulation/` - the PUBLIC FACADE. It only wraps `internal/anysdk`. It contains no logic.
+
+### The facade is sacred (`public/formulation`)
+
+This is the rule most often violated. The facade exists to wrap internal types so internal structs never leak across the public boundary.
+
+- There are exactly THREE files: `interfaces.go`, `wrappers.go`, `formulation.go`. Do not add a fourth (not even a `*_test.go`). The logic and its tests live in `internal/anysdk`; the facade is mechanical wrapping and is covered by internal tests plus integration.
+  - `interfaces.go` - public interface declarations.
+  - `wrappers.go` - the `wrapped*` impls and `wrapSlice_*` / `unwrapSlice_*` helpers.
+  - `formulation.go` - constructors (`New*`) and free functions (e.g. `ApplyPushdown`).
+- Never introduce a public struct in the facade. Every public type is an interface.
+- Never vary the wrapping pattern. Follow exactly what is already there:
+  - `type wrappedX struct { inner anysdk.X }`, methods delegate to `w.inner.Method()`.
+  - `func (w *wrappedX) unwrap() anysdk.X { return w.inner }` when the value is passed back into internal.
+  - `wrapSlice_X(in []anysdk.X) []X` and `unwrapSlice_X(in []X) []anysdk.X`.
+  - Constructors build the internal value via `anysdk.NewX(...)` and wrap it: `&wrappedX{inner: anysdk.NewX(...)}`.
+- A public wrapper WRAPS the internal type. It must not re-declare the internal type's fields. Hold `inner anysdk.X` and delegate; do not copy `field-by-field` translations into the facade.
+- No "creativity" in the facade - no bespoke conversion logic, no helper structs, no logic that should have lived in `internal/anysdk`. If you find yourself writing real logic in the facade, it belongs in internal.
+- Mirror internal method names on the public interface (e.g. internal `QueryParams()` -> public `QueryParams()`), so wrapping is a one-line delegation.
+
+When adding a public method that surfaces an internal one, add it to the public interface and the wrapper, mirroring an existing example (e.g. how `GetPaginationResponseTerminatorTokenSemantic` is surfaced on both wrapped operation-store types).
+
+## Type and struct conventions
+
+- Structures are lowercase (unexported) by default. The standard internal pattern is: exported interface + lowercase `standard*` implementation + `New*` constructor. Example: `QueryParamPushdown` (interface) / `standardQueryParamPushdown` (impl) / and a constructor or `GetTesting*` helper.
+- If a type needs to be published (consumed across a package boundary), publish an INTERFACE, not a struct.
+- The only acceptable exported struct is a data-transfer object for serde - i.e. a type with `json`/`yaml` tags that is unmarshalled from a provider document (e.g. `RegistryConfig`, the `standard*` config structs whose exported fields exist so the serializer can populate them). A plain value-carrier struct that is not deserialized should be an interface.
+- Do not expose `internal/anysdk` structs through the public API. Wrap them.
+
+## Additive and backward compatible
+
+- New behavior is opt-in via an OpenAPI/`provider.yaml` flag, a method extension, or an explicit builder/argument. With the flag/config absent, behavior must be byte-for-byte unchanged.
+- Do not change existing exported signatures of stable APIs. Add new methods/constructors instead.
+- New extension keys go in `internal/anysdk/const.go`.
+- Reuse existing constants (e.g. `ODataDialect`) rather than re-declaring literals.
+
+## Testing
+
+- Add a test for everything you implement. Put the test where the logic is (almost always `internal/anysdk` or `pkg/...`), never in the facade.
+- Do not break existing tests.
+- White-box tests (`package anysdk`) can exercise unexported helpers; external tests (`package anysdk_test`) use the exported surface. An external test can still pass a fake that structurally satisfies an unexported interface parameter.
+- For config-driven types, build fixtures with the `GetTesting*` helper plus `yaml.Unmarshal` (see existing `query_param_pushdown` / `pagination` tests).
+
+## Formatting and lint
+
+`gofmt`/`goimports` clean and `golangci-lint run` with zero issues is a hard requirement.
+
+- Tabs for indentation.
+- `gofmt` does NOT column-align consecutive single-line function declarations. Write one-line getters one-per-line with a single space before `{` (do not pad them into a column, or gofmt will reformat and the lint check fails).
+- `gofmt` DOES align struct fields and `const`/`var` blocks - keep those aligned.
+- Prefer leading doc comments over trailing aligned inline comments on struct fields (trailing-comment alignment is fragile to hand-format).
+- Do not orphan unexported functions; an unused unexported func trips `staticcheck` (U1000). If a refactor leaves a helper unused, route a caller through it or delete it.
+- One `init()` per file.
+
+## Footprint
+
+- Touch as few files as practical. Make the change, not adjacent "improvements".
+- Keep changes cohesive and minimal so the diff is easy to review.
+
+## Build and verification
+
+Before considering work done (and always before a release tag), run:
+
+```
+go build ./...
+go test ./...
+golangci-lint run
+```
+
+## Workflow, git, and releases
+
+- Make changes in the current long-lived feature branch. The maintainer stages, commits, pushes, and raises the PR.
+- Provide the PR title and body fenced with `~~~` (not triple backticks) so copy-paste into VS Code does not break.
+- An unrelated change should be a branch off `main`, not stacked on an open PR.
+- Releases use the `v0.5.3-alphaNN` tag scheme. Tag the squash-merge commit on `main` (verify `git rev-parse <tag>` == `git rev-parse origin/main`) only after the PR is merged and CI is green. The maintainer cuts/pushes tags.

--- a/cicd/schema-definitions/README.md
+++ b/cicd/schema-definitions/README.md
@@ -1,0 +1,33 @@
+# any-sdk schema definitions
+
+JSON Schema (Draft 2020-12) definitions for the stackql provider document model. These are the canonical, publishable artefacts; CI keeps them in lockstep with the loader code.
+
+## Artefacts
+
+- `provider.schema.json` - the provider document (`provider.yaml`): `id`, `name`, `version`, `providerServices`, and `config`. Stable `$id`: `https://schemas.stackql.io/any-sdk/provider.schema.json`. This is the primary artefact to register with SchemaStore (matches `**/provider.yaml`).
+- `stackql-config.schema.json` - the stackql `config` block (also surfaced as `x-stackQL-config` at service / resource / method levels). Referenced from `provider.schema.json` via `$ref`. Rejects unknown keys so mistyped or misplaced config keys fail validation rather than being silently ignored.
+- `service-resources.schema.json`, `resources-core.schema.json`, `fragmented-resources.schema.json`, `local-templated.service-resources.schema.json` - service / resource document schemas.
+- `openapi-3.0.schema.json` - vendored OpenAPI 3.0 meta-schema used by the service schemas.
+
+## Keeping the schema in step with the code (CI)
+
+`internal/anysdk/config_schema_test.go` asserts struct-schema agreement: every yaml key on the loader's `standardStackQLConfig` must appear in `stackql-config.schema.json` and vice versa, that the config object rejects unknown keys, and that a sample provider document validates end to end (exercising the `provider -> config` `$ref`). These run under `go test ./...` in CI, so a config field added in code without a matching schema change fails the build.
+
+## Coverage status
+
+Fully modelled today: the provider document envelope and the top-level `config` keys (typos at this level are caught). Deeper structures referenced from `config` (`pagination`, `queryParamPushdown`, `retry`, `variations`, `views`, `sqlExternalTables`, `auth`) are currently typed as permissive objects; tightening these, plus modelling method-level `request.nativeCasing` and `x-stackQL-graphQL`, is follow-up work.
+
+## SchemaStore registration
+
+Registration is performed manually (out of scope of this repo's automation). To register, add a catalog entry to https://github.com/SchemaStore/schemastore mapping provider documents to the published `$id`, for example:
+
+```json
+{
+  "name": "stackql any-sdk provider document",
+  "description": "stackql any-sdk provider.yaml",
+  "fileMatch": ["**/provider.yaml"],
+  "url": "https://schemas.stackql.io/any-sdk/provider.schema.json"
+}
+```
+
+The referenced `stackql-config.schema.json` must be published alongside `provider.schema.json` at the same base URL so the relative `$ref` resolves.

--- a/cicd/schema-definitions/provider.schema.json
+++ b/cicd/schema-definitions/provider.schema.json
@@ -94,6 +94,9 @@
         "additionalProperties": true
       }
     },
+    "config": {
+      "$ref": "./stackql-config.schema.json"
+    },
     "x-stackQL-info": {
       "type": "object",
       "additionalProperties": true

--- a/cicd/schema-definitions/stackql-config.schema.json
+++ b/cicd/schema-definitions/stackql-config.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stackql-config.schema.json",
+  "title": "stackql any-sdk config block (x-stackQL-config)",
+  "description": "The stackql configuration block. It appears under `config` in a provider document and, as `x-stackQL-config`, at service / resource / method inheritance levels. Property names mirror the yaml tags on the loader's config struct; unknown keys are rejected so mistyped or misplaced keys fail validation rather than being silently ignored.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "auth": {
+      "type": "object",
+      "description": "Authentication descriptor. Shape varies by auth type; not yet fully modelled."
+    },
+    "queryParamTranspose": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestBodyTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "pagination": {
+      "type": "object",
+      "description": "Pagination semantics (request/response token strategies). Not yet fully modelled."
+    },
+    "variations": {
+      "type": "object",
+      "description": "Provider variations (e.g. implicit union of object schemas). Not yet fully modelled."
+    },
+    "views": {
+      "type": "object",
+      "description": "Named SQL views keyed by view name. Not yet fully modelled."
+    },
+    "sqlExternalTables": {
+      "type": "object",
+      "description": "External SQL tables keyed by table name. Not yet fully modelled."
+    },
+    "queryParamPushdown": {
+      "type": "object",
+      "description": "Query parameter push-down configuration. Not yet fully modelled."
+    },
+    "retry": {
+      "type": "object",
+      "description": "Retry policy. Not yet fully modelled."
+    },
+    "minStackQLVersion": {
+      "type": "string",
+      "description": "Minimum stackql version required to consume this provider."
+    },
+    "snake_case_aliases": {
+      "type": "boolean",
+      "description": "When true, multi-word response columns are exposed under snake_case aliases."
+    }
+  },
+  "$defs": {
+    "transform": {
+      "type": "object",
+      "description": "A text/stream transform descriptor.",
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/internal/anysdk/casing_resolution_test.go
+++ b/internal/anysdk/casing_resolution_test.go
@@ -1,0 +1,193 @@
+package anysdk
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/stackql/any-sdk/pkg/casing"
+)
+
+// stringProperty is a tiny helper for building object-schema fixtures.
+func stringProperty() *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{Type: "string"}}
+}
+
+func columnsByName(cols []ColumnDescriptor) map[string]ColumnDescriptor {
+	rv := make(map[string]ColumnDescriptor, len(cols))
+	for _, c := range cols {
+		rv[c.GetName()] = c
+	}
+	return rv
+}
+
+// TestSnakeCaseAliasColumnWireName covers issue #108: when snake_case_aliases is
+// enabled the column display name is snake-cased but GetWireName retains the wire
+// property name so data extraction is keyed correctly.
+func TestSnakeCaseAliasColumnWireName(t *testing.T) {
+	prov := &standardProvider{StackQLConfig: &standardStackQLConfig{SnakeCaseAliases: true}}
+	svc := &standardService{Provider: prov}
+	sc := &openapi3.Schema{
+		Type: "object",
+		Properties: openapi3.Schemas{
+			"VpcId":        stringProperty(),
+			"cidrBlock":    stringProperty(),
+			"echoed_query": stringProperty(),
+		},
+	}
+	s := newStandardSchema(sc, svc, "Echo", "")
+
+	cols := columnsByName(s.Tabulate(false, "").GetColumns())
+
+	cases := []struct {
+		displayName  string
+		wantWireName string
+	}{
+		{"vpc_id", "VpcId"},
+		{"cidr_block", "cidrBlock"},
+		{"echoed_query", "echoed_query"}, // single-word: snake == wire
+	}
+	for _, c := range cases {
+		col, ok := cols[c.displayName]
+		if !ok {
+			t.Fatalf("expected a column named %q; got columns %v", c.displayName, keysOf(cols))
+		}
+		if got := col.GetWireName(); got != c.wantWireName {
+			t.Errorf("column %q: GetWireName() = %q, want %q", c.displayName, got, c.wantWireName)
+		}
+	}
+}
+
+// TestSnakeCaseAliasesDisabledIsWireKeyed asserts the default (flag absent)
+// behaviour is unchanged: display name and wire name are both the wire name.
+func TestSnakeCaseAliasesDisabledIsWireKeyed(t *testing.T) {
+	prov := &standardProvider{StackQLConfig: &standardStackQLConfig{}}
+	svc := &standardService{Provider: prov}
+	sc := &openapi3.Schema{
+		Type: "object",
+		Properties: openapi3.Schemas{
+			"VpcId":     stringProperty(),
+			"cidrBlock": stringProperty(),
+		},
+	}
+	s := newStandardSchema(sc, svc, "Echo", "")
+
+	cols := columnsByName(s.Tabulate(false, "").GetColumns())
+	for _, wire := range []string{"VpcId", "cidrBlock"} {
+		col, ok := cols[wire]
+		if !ok {
+			t.Fatalf("expected a column named %q; got columns %v", wire, keysOf(cols))
+		}
+		if got := col.GetWireName(); got != wire {
+			t.Errorf("column %q: GetWireName() = %q, want %q", wire, got, wire)
+		}
+	}
+}
+
+// TestGetParametersIncludingNativeCasing covers issue #109: snake_case keys
+// resolve to their wire (PascalCase) Addressable via direct set membership when
+// the method declares request.nativeCasing.
+func TestGetParametersIncludingNativeCasing(t *testing.T) {
+	m := newPascalCasingTestOperationStore("VpcId", "SubnetId")
+
+	params := m.GetParametersIncludingNativeCasing()
+
+	wantSnakeToWire := map[string]string{
+		"vpc_id":    "VpcId",
+		"subnet_id": "SubnetId",
+	}
+	for snakeKey, wireName := range wantSnakeToWire {
+		addr, ok := params[snakeKey]
+		if !ok {
+			t.Fatalf("expected snake alias %q in parameter set; got %v", snakeKey, keysOfAddressable(params))
+		}
+		if got := addr.GetName(); got != wireName {
+			t.Errorf("snake alias %q resolved to wire name %q, want %q", snakeKey, got, wireName)
+		}
+	}
+	// The original wire keys must still be present and unchanged.
+	for _, wire := range []string{"VpcId", "SubnetId"} {
+		if _, ok := params[wire]; !ok {
+			t.Errorf("expected wire key %q to remain in parameter set", wire)
+		}
+	}
+	if len(params) != 4 {
+		t.Errorf("expected 4 entries (2 wire + 2 snake), got %d: %v", len(params), keysOfAddressable(params))
+	}
+}
+
+// TestGetParametersIncludingNativeCasingAbsentIsUnchanged asserts that, absent
+// request.nativeCasing, the resolver set is identical to the wire-keyed set.
+func TestGetParametersIncludingNativeCasingAbsentIsUnchanged(t *testing.T) {
+	m := &standardOpenAPIOperationStore{
+		OperationRef: &OperationRef{Value: &openapi3.Operation{
+			Parameters: openapi3.Parameters{
+				queryParameterRef("VpcId"),
+				queryParameterRef("SubnetId"),
+			},
+		}},
+	}
+
+	params := m.GetParametersIncludingNativeCasing()
+	if len(params) != 2 {
+		t.Fatalf("expected only the 2 wire keys, got %d: %v", len(params), keysOfAddressable(params))
+	}
+	for _, wire := range []string{"VpcId", "SubnetId"} {
+		if _, ok := params[wire]; !ok {
+			t.Errorf("expected wire key %q", wire)
+		}
+	}
+}
+
+func newPascalCasingTestOperationStore(queryParamNames ...string) *standardOpenAPIOperationStore {
+	refs := make(openapi3.Parameters, 0, len(queryParamNames))
+	for _, name := range queryParamNames {
+		refs = append(refs, queryParameterRef(name))
+	}
+	return &standardOpenAPIOperationStore{
+		OperationRef: &OperationRef{Value: &openapi3.Operation{Parameters: refs}},
+		Request:      &standardExpectedRequest{NativeCasing: casing.Pascal},
+	}
+}
+
+func queryParameterRef(name string) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{Value: &openapi3.Parameter{Name: name, In: openapi3.ParameterInQuery}}
+}
+
+// TestHasRequestBodyContent covers the body-presence guard that lets a request
+// block carry metadata (e.g. nativeCasing on a body-less GET) without forcing
+// body marshalling. NewHttpParameters seeds an empty non-nil map, so an empty map
+// must count as "no content".
+func TestHasRequestBodyContent(t *testing.T) {
+	cases := []struct {
+		name string
+		body interface{}
+		want bool
+	}{
+		{"nil interface", nil, false},
+		{"nil map", map[string]interface{}(nil), false},
+		{"empty map", map[string]interface{}{}, false},
+		{"populated map", map[string]interface{}{"name": "x"}, true},
+	}
+	for _, c := range cases {
+		if got := hasRequestBodyContent(c.body); got != c.want {
+			t.Errorf("%s: hasRequestBodyContent() = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+func keysOf(m map[string]ColumnDescriptor) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	return rv
+}
+
+func keysOfAddressable(m map[string]Addressable) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	return rv
+}

--- a/internal/anysdk/config_schema_test.go
+++ b/internal/anysdk/config_schema_test.go
@@ -1,0 +1,142 @@
+package anysdk
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stackql/any-sdk/pkg/docval"
+)
+
+// configSchemaPath is the canonical (published) config schema artefact.
+var configSchemaPath = filepath.Join("..", "..", "cicd", "schema-definitions", "stackql-config.schema.json")
+
+// schemaSurface is a minimal view of the bits of a JSON Schema object we assert on.
+type schemaSurface struct {
+	AdditionalProperties *bool                      `json:"additionalProperties"`
+	Properties           map[string]json.RawMessage `json:"properties"`
+}
+
+func readConfigSchema(t *testing.T) schemaSurface {
+	t.Helper()
+	b, err := os.ReadFile(configSchemaPath)
+	if err != nil {
+		t.Fatalf("read config schema %q: %v", configSchemaPath, err)
+	}
+	var s schemaSurface
+	if err := json.Unmarshal(b, &s); err != nil {
+		t.Fatalf("parse config schema: %v", err)
+	}
+	return s
+}
+
+// configStructYamlTags returns the yaml tag names of standardStackQLConfig that
+// are part of the document surface (excluding `-`). This is the source of truth
+// the schema must mirror.
+func configStructYamlTags() map[string]struct{} {
+	rv := map[string]struct{}{}
+	tp := reflect.TypeOf(standardStackQLConfig{})
+	for i := 0; i < tp.NumField(); i++ {
+		name := strings.Split(tp.Field(i).Tag.Get("yaml"), ",")[0]
+		if name == "" || name == "-" {
+			continue
+		}
+		rv[name] = struct{}{}
+	}
+	return rv
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	sort.Strings(rv)
+	return rv
+}
+
+// TestStackQLConfigSchemaMatchesStruct is the struct-schema agreement guard
+// (issue #110): every config key the loader understands must be modelled in the
+// published schema and vice versa, so the artefact cannot silently drift from the
+// code. It also asserts the config object rejects unknown keys.
+func TestStackQLConfigSchemaMatchesStruct(t *testing.T) {
+	schema := readConfigSchema(t)
+
+	if schema.AdditionalProperties == nil || *schema.AdditionalProperties {
+		t.Errorf("config schema must set additionalProperties:false so mistyped keys fail validation")
+	}
+
+	want := configStructYamlTags()
+	got := map[string]struct{}{}
+	for k := range schema.Properties {
+		got[k] = struct{}{}
+	}
+
+	for k := range want {
+		if _, ok := got[k]; !ok {
+			t.Errorf("config key %q exists on standardStackQLConfig but is missing from the schema", k)
+		}
+	}
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("schema models config key %q that no longer exists on standardStackQLConfig", k)
+		}
+	}
+	if t.Failed() {
+		t.Logf("struct yaml tags: %v", sortedKeys(want))
+		t.Logf("schema properties: %v", sortedKeys(got))
+	}
+}
+
+// TestStackQLConfigSchemaAcceptsKnownKeys asserts representative real-world config
+// shapes validate against the published schema.
+func TestStackQLConfigSchemaAcceptsKnownKeys(t *testing.T) {
+	schemaBytes, err := os.ReadFile(configSchemaPath)
+	if err != nil {
+		t.Fatalf("read config schema: %v", err)
+	}
+	doc := []byte(`{
+		"auth": {"type": "aws_signing_v4", "credentialsenvvar": "AWS_SECRET_ACCESS_KEY"},
+		"sqlExternalTables": {"information_schema.applicable_roles": {"name": "applicable_roles"}},
+		"requestBodyTranslate": {"algorithm": "naive_request_body_json"},
+		"minStackQLVersion": "v0.5.0",
+		"snake_case_aliases": true
+	}`)
+	if _, err := docval.ValidateAndParse(doc, schemaBytes, "config"); err != nil {
+		t.Fatalf("expected known config keys to validate, got: %v", err)
+	}
+}
+
+// TestStackQLConfigSchemaRejectsUnknownKey is the "CI fails on mistyped keys"
+// guarantee: a typo'd config key must be rejected rather than silently ignored.
+func TestStackQLConfigSchemaRejectsUnknownKey(t *testing.T) {
+	schemaBytes, err := os.ReadFile(configSchemaPath)
+	if err != nil {
+		t.Fatalf("read config schema: %v", err)
+	}
+	// `snake_case_alias` (singular) is a common typo of `snake_case_aliases`.
+	doc := []byte(`{"snake_case_alias": true}`)
+	if _, err := docval.ValidateAndParse(doc, schemaBytes, "config"); err == nil {
+		t.Fatalf("expected mistyped config key to fail validation, got nil error")
+	}
+}
+
+// TestProviderSchemaResolvesConfigRef validates a real provider document against
+// the published provider schema, exercising the provider -> config $ref and
+// confirming a sample document validates end to end (issue #110 acceptance).
+func TestProviderSchemaResolvesConfigRef(t *testing.T) {
+	schemaRoot := filepath.Join("..", "..", "cicd", "schema-definitions")
+	validator := docval.NewFileValidator(schemaRoot)
+	docPath := filepath.Join("testdata", "registry", "src", "local_openssl", "v0.1.0", "provider.yaml")
+	rv, err := validator.ValidateAndParseFile(docPath, "provider.schema.json")
+	if err != nil {
+		t.Fatalf("expected provider doc to validate, got: %v", err)
+	}
+	if rv["name"] != "local_openssl" {
+		t.Fatalf("unexpected provider name: %v", rv["name"])
+	}
+}

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -98,6 +98,7 @@ type OperationStore interface {
 	GetRequiredParameters() map[string]Addressable
 	GetOptionalParameters() map[string]Addressable
 	GetParameter(paramKey string) (Addressable, bool)
+	GetParametersIncludingNativeCasing() map[string]Addressable
 	GetUnionRequiredParameters() (map[string]Addressable, error)
 	GetPaginationAlgorithm() string
 	GetPaginationResponseTokenSemantic() (TokenSemantic, bool)
@@ -1323,6 +1324,36 @@ func (m *standardOpenAPIOperationStore) GetParameter(paramKey string) (Addressab
 	return nil, false
 }
 
+// GetParametersIncludingNativeCasing returns the full input parameter set keyed
+// by wire name, augmented (when the method declares request.nativeCasing) with
+// snake_case aliases mapping to the same Addressable. This lets a consumer resolve
+// snake_case WHERE/INSERT keys by direct set membership without special-casing the
+// reverse-casing retry at every resolution point. Absent native casing it is
+// identical to the wire-keyed set, preserving existing behaviour. A snake alias is
+// never allowed to clobber a real wire parameter of the same name.
+func (m *standardOpenAPIOperationStore) GetParametersIncludingNativeCasing() map[string]Addressable {
+	base := m.GetParameters()
+	nc := m.GetRequestNativeCasing()
+	if nc == "" {
+		return base
+	}
+	retVal := make(map[string]Addressable, len(base))
+	for k, v := range base {
+		retVal[k] = v
+	}
+	for wireKey, v := range base {
+		snakeKey := casing.ToSnake(wireKey)
+		if snakeKey == wireKey {
+			continue
+		}
+		if _, exists := retVal[snakeKey]; exists {
+			continue
+		}
+		retVal[snakeKey] = v
+	}
+	return retVal
+}
+
 // GetParameterOrError resolves a parameter (including reverse-casing) and, on a
 // final miss, returns a *ParameterNotFoundError listing the wire-format names.
 func (m *standardOpenAPIOperationStore) GetParameterOrError(paramKey string) (Addressable, error) {
@@ -1509,6 +1540,20 @@ func (op *standardOpenAPIOperationStore) marshalBody(body interface{}, expectedR
 	return dto.NewMarshalledBody(nil, fmt.Errorf("media type = '%s' not supported", expectedRequest.GetBodyMediaType()))
 }
 
+// hasRequestBodyContent reports whether requestBody carries anything to marshal.
+// An empty (or nil) body map means the method's request block exists only to carry
+// metadata (e.g. request.nativeCasing on a body-less GET); NewHttpParameters seeds
+// RequestBody with an empty non-nil map, so emptiness - not nil-ness - is the test.
+func hasRequestBodyContent(requestBody interface{}) bool {
+	if util.IsNil(requestBody) {
+		return false
+	}
+	if bm, ok := requestBody.(map[string]interface{}); ok {
+		return len(bm) > 0
+	}
+	return true
+}
+
 func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc Service, inputParams HttpParameters, requestBody interface{}) (*openapi3filter.RequestValidationInput, error) {
 
 	params := op.OperationRef.Value.Parameters
@@ -1595,21 +1640,23 @@ func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc S
 	}
 	contentTypeHeaderRequired := false
 	var bodyReader io.Reader
-	// predOne := !util.IsNil(requestBody)
-	predTwo := !util.IsNil(op.Request)
-	if predTwo {
+	if op.Request != nil {
 		// TODO: transform
 		marshalledBody := op.marshalBody(requestBody, op.Request)
 		b := marshalledBody.GetBytes()
 		marshalledBodyErr, hassError := marshalledBody.GetError()
 		if hassError {
-			return nil, marshalledBodyErr
-		}
-		if len(b) > 0 {
+			// A request block may be declared purely to carry metadata (e.g.
+			// request.nativeCasing on a body-less GET). With no body content to
+			// marshal there is no media type to resolve, so a marshalling error is
+			// only fatal when there is actually a body to send.
+			if hasRequestBodyContent(requestBody) {
+				return nil, marshalledBodyErr
+			}
+		} else if len(b) > 0 {
 			bodyReader = bytes.NewReader(b)
 			contentTypeHeaderRequired = true
 		}
-
 	}
 	// TODO: clean up
 	sv = strings.TrimSuffix(sv, "/")

--- a/internal/anysdk/operation_store_test.go
+++ b/internal/anysdk/operation_store_test.go
@@ -7,10 +7,46 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stackql/any-sdk/pkg/casing"
 	"github.com/stackql/any-sdk/test/pkg/testutil"
 
 	"gotest.tools/assert"
 )
+
+// TestParameterizeRequestBlockWithoutBodyMediaType reproduces issue #109's
+// secondary note: a GET that declares a request block solely to carry
+// request.nativeCasing (no body, no mediaType) must still assemble. Before the
+// fix, parameterize unconditionally marshalled the body and failed with
+// "media type = ” not supported".
+func TestParameterizeRequestBlockWithoutBodyMediaType(t *testing.T) {
+	setupFileRoot(t)
+
+	b, err := GetServiceDocBytes(fmt.Sprintf("k8s/%s/services/core_v1.yaml", "v0.1.0"), "")
+	assert.NilError(t, err)
+
+	l := newLoader()
+	svc, err := l.loadFromBytes(b)
+	assert.NilError(t, err)
+
+	rsc, err := svc.GetResource("node")
+	assert.NilError(t, err)
+
+	ops, _, ok := rsc.GetFirstNamespaceMethodMatchFromSQLVerb("select", nil)
+	assert.Assert(t, ok)
+	assert.Assert(t, ops != nil)
+
+	// Attach a request block carrying only native casing - as on a body-less GET -
+	// with no body media type declared.
+	ops.setRequest(&standardExpectedRequest{NativeCasing: casing.Pascal})
+
+	params := NewHttpParameters(ops)
+	err = params.IngestMap(map[string]interface{}{"cluster_addr": "k8shost"})
+	assert.NilError(t, err)
+
+	rvi, err := ops.parameterize(dummmyK8sProv, svc, params, params.GetRequestBody())
+	assert.NilError(t, err)
+	assert.Assert(t, rvi != nil)
+}
 
 var (
 	dummmyContrivedProv Provider = NewProvider("", "github", "", "")

--- a/internal/anysdk/schema.go
+++ b/internal/anysdk/schema.go
@@ -1002,15 +1002,17 @@ func (s *standardSchema) getPropertiesColumns() []ColumnDescriptor {
 		valSchema := val.Value
 		if valSchema != nil {
 			// The column's display/DDL name is snake-aliased when the provider opts
-			// in; the wire property name (k) is retained on the Schema for response
-			// navigation.
+			// in; the wire property name (k) is retained both on the Schema for
+			// response navigation and as the column's wire name so consumers key
+			// data extraction by wire rather than by the snake alias.
 			name := k
 			if snakeAliases {
 				name = casing.ToSnake(k)
 			}
-			col := newColumnDescriptor(
+			col := newColumnDescriptorWithWireName(
 				"",
 				name,
+				k,
 				"",
 				"",
 				nil,

--- a/internal/anysdk/table.go
+++ b/internal/anysdk/table.go
@@ -26,7 +26,11 @@ type ColumnDescriptor interface {
 	GetRepresentativeSchema() Schema
 	GetSchema() Schema
 	GetVal() *sqlparser.SQLVal
-	setName(string)
+	// GetWireName returns the foreign-API property name to key response data
+	// extraction by. It differs from GetName only when the display name has been
+	// aliased (e.g. snake_case_aliases), in which case GetName is the snake alias
+	// and GetWireName is the original wire property name. It defaults to GetName.
+	GetWireName() string
 }
 
 type Relation interface {
@@ -43,6 +47,7 @@ type Column interface {
 type standardColumnDescriptor struct {
 	Alias        string
 	Name         string
+	WireName     string
 	Qualifier    string
 	Schema       Schema
 	DecoratedCol string
@@ -70,11 +75,14 @@ func (cd standardColumnDescriptor) GetAlias() string {
 	return cd.Alias
 }
 
-func (cd standardColumnDescriptor) setName(name string) {
-	cd.Name = name
+func (cd standardColumnDescriptor) GetName() string {
+	return cd.Name
 }
 
-func (cd standardColumnDescriptor) GetName() string {
+func (cd standardColumnDescriptor) GetWireName() string {
+	if cd.WireName != "" {
+		return cd.WireName
+	}
 	return cd.Name
 }
 
@@ -110,7 +118,14 @@ func NewColumnDescriptor(alias string, name string, qualifier string, decoratedC
 }
 
 func newColumnDescriptor(alias string, name string, qualifier string, decoratedCol string, node sqlparser.SQLNode, schema Schema, val *sqlparser.SQLVal) ColumnDescriptor {
-	return standardColumnDescriptor{Alias: alias, Name: name, Qualifier: qualifier, DecoratedCol: decoratedCol, Schema: schema, Val: val, Node: node}
+	return newColumnDescriptorWithWireName(alias, name, "", qualifier, decoratedCol, node, schema, val)
+}
+
+// newColumnDescriptorWithWireName is newColumnDescriptor plus an explicit wire
+// name, used where the display name is aliased away from the wire property name
+// (e.g. snake_case_aliases) so consumers can still key data extraction by wire.
+func newColumnDescriptorWithWireName(alias string, name string, wireName string, qualifier string, decoratedCol string, node sqlparser.SQLNode, schema Schema, val *sqlparser.SQLVal) ColumnDescriptor {
+	return standardColumnDescriptor{Alias: alias, Name: name, WireName: wireName, Qualifier: qualifier, DecoratedCol: decoratedCol, Schema: schema, Val: val, Node: node}
 }
 
 func newNilTabulation(svc OpenAPIService, key string, path string) Tabulation {
@@ -165,7 +180,12 @@ func (t *standardTabulation) RenameColumnsToXml() Tabulation {
 		if v.GetSchema() != nil {
 			alias := v.GetSchema().getXmlAlias()
 			if alias != "" {
-				t.columns[i].setName(alias)
+				// standardColumnDescriptor is stored by value, so the rename only
+				// sticks if we write the modified copy back into the slice.
+				if cd, ok := v.(standardColumnDescriptor); ok {
+					cd.Name = alias
+					t.columns[i] = cd
+				}
 			}
 		}
 	}

--- a/pkg/docval/testdata/schema-definitions/provider.schema.json
+++ b/pkg/docval/testdata/schema-definitions/provider.schema.json
@@ -94,6 +94,9 @@
         "additionalProperties": true
       }
     },
+    "config": {
+      "$ref": "./stackql-config.schema.json"
+    },
     "x-stackQL-info": {
       "type": "object",
       "additionalProperties": true

--- a/pkg/docval/testdata/schema-definitions/stackql-config.schema.json
+++ b/pkg/docval/testdata/schema-definitions/stackql-config.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stackql-config.schema.json",
+  "title": "stackql any-sdk config block (x-stackQL-config)",
+  "description": "The stackql configuration block. It appears under `config` in a provider document and, as `x-stackQL-config`, at service / resource / method inheritance levels. Property names mirror the yaml tags on the loader's config struct; unknown keys are rejected so mistyped or misplaced keys fail validation rather than being silently ignored.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "auth": {
+      "type": "object",
+      "description": "Authentication descriptor. Shape varies by auth type; not yet fully modelled."
+    },
+    "queryParamTranspose": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestBodyTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "pagination": {
+      "type": "object",
+      "description": "Pagination semantics (request/response token strategies). Not yet fully modelled."
+    },
+    "variations": {
+      "type": "object",
+      "description": "Provider variations (e.g. implicit union of object schemas). Not yet fully modelled."
+    },
+    "views": {
+      "type": "object",
+      "description": "Named SQL views keyed by view name. Not yet fully modelled."
+    },
+    "sqlExternalTables": {
+      "type": "object",
+      "description": "External SQL tables keyed by table name. Not yet fully modelled."
+    },
+    "queryParamPushdown": {
+      "type": "object",
+      "description": "Query parameter push-down configuration. Not yet fully modelled."
+    },
+    "retry": {
+      "type": "object",
+      "description": "Retry policy. Not yet fully modelled."
+    },
+    "minStackQLVersion": {
+      "type": "string",
+      "description": "Minimum stackql version required to consume this provider."
+    },
+    "snake_case_aliases": {
+      "type": "boolean",
+      "description": "When true, multi-word response columns are exposed under snake_case aliases."
+    }
+  },
+  "$defs": {
+    "transform": {
+      "type": "object",
+      "description": "A text/stream transform descriptor.",
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/public/discovery/testdata/schema-definitions/provider.schema.json
+++ b/public/discovery/testdata/schema-definitions/provider.schema.json
@@ -94,6 +94,9 @@
         "additionalProperties": true
       }
     },
+    "config": {
+      "$ref": "./stackql-config.schema.json"
+    },
     "x-stackQL-info": {
       "type": "object",
       "additionalProperties": true

--- a/public/discovery/testdata/schema-definitions/stackql-config.schema.json
+++ b/public/discovery/testdata/schema-definitions/stackql-config.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stackql-config.schema.json",
+  "title": "stackql any-sdk config block (x-stackQL-config)",
+  "description": "The stackql configuration block. It appears under `config` in a provider document and, as `x-stackQL-config`, at service / resource / method inheritance levels. Property names mirror the yaml tags on the loader's config struct; unknown keys are rejected so mistyped or misplaced keys fail validation rather than being silently ignored.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "auth": {
+      "type": "object",
+      "description": "Authentication descriptor. Shape varies by auth type; not yet fully modelled."
+    },
+    "queryParamTranspose": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestBodyTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "pagination": {
+      "type": "object",
+      "description": "Pagination semantics (request/response token strategies). Not yet fully modelled."
+    },
+    "variations": {
+      "type": "object",
+      "description": "Provider variations (e.g. implicit union of object schemas). Not yet fully modelled."
+    },
+    "views": {
+      "type": "object",
+      "description": "Named SQL views keyed by view name. Not yet fully modelled."
+    },
+    "sqlExternalTables": {
+      "type": "object",
+      "description": "External SQL tables keyed by table name. Not yet fully modelled."
+    },
+    "queryParamPushdown": {
+      "type": "object",
+      "description": "Query parameter push-down configuration. Not yet fully modelled."
+    },
+    "retry": {
+      "type": "object",
+      "description": "Retry policy. Not yet fully modelled."
+    },
+    "minStackQLVersion": {
+      "type": "string",
+      "description": "Minimum stackql version required to consume this provider."
+    },
+    "snake_case_aliases": {
+      "type": "boolean",
+      "description": "When true, multi-word response columns are exposed under snake_case aliases."
+    }
+  },
+  "$defs": {
+    "transform": {
+      "type": "object",
+      "description": "A text/stream transform descriptor.",
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/public/formulation/formulation.go
+++ b/public/formulation/formulation.go
@@ -57,6 +57,7 @@ type ColumnDescriptor interface {
 	GetRepresentativeSchema() Schema
 	GetSchema() Schema
 	GetVal() *sqlparser.SQLVal
+	GetWireName() string
 	unwrap() anysdk.ColumnDescriptor
 }
 
@@ -442,24 +443,6 @@ type ArmouryGenerator interface {
 	BaseArmouryGenerator
 	unwrap() anysdkhttp.ArmouryGenerator
 }
-
-type wrappedArmouryGenerator struct {
-	inner anysdkhttp.ArmouryGenerator
-}
-
-func (wag *wrappedArmouryGenerator) GetHTTPArmoury() (HTTPArmoury, error) {
-	inner, err := wag.inner.GetHTTPArmoury()
-	if err != nil {
-		return nil, err
-	}
-	return &wrappedHTTPArmoury{inner: inner}, nil
-}
-
-func (wag *wrappedArmouryGenerator) unwrap() anysdkhttp.ArmouryGenerator {
-	return wag.inner
-}
-
-// anysdkhttp.ArmouryGenerator
 
 func NewPayload(
 	armouryGenerator BaseArmouryGenerator,

--- a/public/formulation/interfaces.go
+++ b/public/formulation/interfaces.go
@@ -241,6 +241,7 @@ type OperationStore interface {
 	GetPaginationResponseTerminatorTokenSemantic() (TokenSemantic, bool)
 	GetQueryParamPushdown() (QueryParamPushdown, bool)
 	GetParameter(paramKey string) (Addressable, bool)
+	GetParametersIncludingNativeCasing() map[string]Addressable
 	GetRequestBodySchema() (Schema, error)
 	GetRequiredNonBodyParameters() map[string]Addressable
 	GetRequiredParameters() map[string]Addressable

--- a/public/formulation/wrappers.go
+++ b/public/formulation/wrappers.go
@@ -916,6 +916,11 @@ func (w *wrappedOperationStore) GetParameter(paramKey string) (Addressable, bool
 	return &wrappedAddressable{inner: r0}, r1
 }
 
+func (w *wrappedOperationStore) GetParametersIncludingNativeCasing() map[string]Addressable {
+	r0 := w.inner.GetParametersIncludingNativeCasing()
+	return wrapMapString_Addressable(r0)
+}
+
 func (w *wrappedOperationStore) GetRequestBodySchema() (Schema, error) {
 	r0, r1 := w.inner.GetRequestBodySchema()
 	return newWrappedSchemaFromAnySdkSchema(r0), r1
@@ -1591,6 +1596,11 @@ func (w *wrappedStandardOperationStore) GetQueryParamPushdown() (QueryParamPushd
 func (w *wrappedStandardOperationStore) GetParameter(paramKey string) (Addressable, bool) {
 	r0, r1 := w.inner.GetParameter(paramKey)
 	return &wrappedAddressable{inner: r0}, r1
+}
+
+func (w *wrappedStandardOperationStore) GetParametersIncludingNativeCasing() map[string]Addressable {
+	r0 := w.inner.GetParametersIncludingNativeCasing()
+	return wrapMapString_Addressable(r0)
 }
 
 func (w *wrappedStandardOperationStore) GetRequestBodySchema() (Schema, error) {
@@ -3199,6 +3209,10 @@ func (w *wrappedColumnDescriptor) GetAlias() string {
 
 func (w *wrappedColumnDescriptor) GetName() string {
 	return w.inner.GetName()
+}
+
+func (w *wrappedColumnDescriptor) GetWireName() string {
+	return w.inner.GetWireName()
 }
 
 func (w *wrappedColumnDescriptor) GetIdentifier() string {

--- a/public/radix_tree_address_space/testdata/schema-definitions/provider.schema.json
+++ b/public/radix_tree_address_space/testdata/schema-definitions/provider.schema.json
@@ -94,6 +94,9 @@
         "additionalProperties": true
       }
     },
+    "config": {
+      "$ref": "./stackql-config.schema.json"
+    },
     "x-stackQL-info": {
       "type": "object",
       "additionalProperties": true

--- a/public/radix_tree_address_space/testdata/schema-definitions/stackql-config.schema.json
+++ b/public/radix_tree_address_space/testdata/schema-definitions/stackql-config.schema.json
@@ -1,0 +1,73 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "stackql-config.schema.json",
+  "title": "stackql any-sdk config block (x-stackQL-config)",
+  "description": "The stackql configuration block. It appears under `config` in a provider document and, as `x-stackQL-config`, at service / resource / method inheritance levels. Property names mirror the yaml tags on the loader's config struct; unknown keys are rejected so mistyped or misplaced keys fail validation rather than being silently ignored.",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "auth": {
+      "type": "object",
+      "description": "Authentication descriptor. Shape varies by auth type; not yet fully modelled."
+    },
+    "queryParamTranspose": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "requestBodyTranslate": {
+      "$ref": "#/$defs/transform"
+    },
+    "pagination": {
+      "type": "object",
+      "description": "Pagination semantics (request/response token strategies). Not yet fully modelled."
+    },
+    "variations": {
+      "type": "object",
+      "description": "Provider variations (e.g. implicit union of object schemas). Not yet fully modelled."
+    },
+    "views": {
+      "type": "object",
+      "description": "Named SQL views keyed by view name. Not yet fully modelled."
+    },
+    "sqlExternalTables": {
+      "type": "object",
+      "description": "External SQL tables keyed by table name. Not yet fully modelled."
+    },
+    "queryParamPushdown": {
+      "type": "object",
+      "description": "Query parameter push-down configuration. Not yet fully modelled."
+    },
+    "retry": {
+      "type": "object",
+      "description": "Retry policy. Not yet fully modelled."
+    },
+    "minStackQLVersion": {
+      "type": "string",
+      "description": "Minimum stackql version required to consume this provider."
+    },
+    "snake_case_aliases": {
+      "type": "boolean",
+      "description": "When true, multi-word response columns are exposed under snake_case aliases."
+    }
+  },
+  "$defs": {
+    "transform": {
+      "type": "object",
+      "description": "A text/stream transform descriptor.",
+      "additionalProperties": false,
+      "properties": {
+        "algorithm": {
+          "type": "string"
+        },
+        "type": {
+          "type": "string"
+        },
+        "body": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #108, #109, #110.

### #108 - multi-word snake_case_aliases columns return null
`ColumnDescriptor.GetWireName()` retains the wire property name for data extraction while the display name stays snake-cased. Recorded at the single chokepoint `getPropertiesColumns`; surfaced on the facade.

### #109 - snake WHERE/INSERT key resolution + GET request-block assembly
- `OperationStore.GetParametersIncludingNativeCasing()` exposes the input parameter set augmented with snake aliases (-> same wire Addressable) when `request.nativeCasing` is declared; required/optional sets untouched so selectivity counts are preserved. Surfaced on the facade.
- Fixed the secondary note: `parameterize` marshalled a body whenever `op.Request != nil`, so a body-less GET declaring a request block solely for `nativeCasing` failed with "media type not supported". The marshalling error is now only fatal when there is real body content.

### #110 - JSON Schema for the provider document
- New `cicd/schema-definitions/stackql-config.schema.json` (Draft 2020-12) modelling the `config` block from `standardStackQLConfig`, with `additionalProperties:false`. Wired into `provider.schema.json` via `$ref`.
- Struct-schema agreement test + sample-doc validation + unknown-key rejection run under `go test ./...` (CI), so the published artefact cannot drift from the loader.
- README documents the artefacts, stable `$id`, coverage status, and the SchemaStore registration snippet (registration itself is manual/out of scope).

### Incidental cleanups (in touched files)
- Removed the ineffective value-receiver `setName` (SA4005) and made `RenameColumnsToXml` effective (it was a silent no-op; XML tests confirm no regression).
- Deleted the dead `wrappedArmouryGenerator`.

## Tests
New: column wire-name retention, aliases-off default, snake->wire resolution, no-native-casing pass-through, `hasRequestBodyContent`, GET request-block assembly repro, and the four schema tests (agreement, accept-known, reject-unknown, provider $ref resolution).

## Verification
`go build ./...`, `go test ./...`, `gofmt`, `golangci-lint run` all clean for the changed files.

## Deferred (follow-up)
Deeper modelling of nested config structures (pagination/queryParamPushdown/retry/variations/views/sqlExternalTables/auth), method-level `request.nativeCasing`, and `x-stackQL-graphQL`.
