### PR TITLE
fix(casing): xml: name and snake/native aliases must land in GetWireName, not GetName (alpha09 column-naming regression)

### DIFF
--- a/internal/anysdk/schema.go
+++ b/internal/anysdk/schema.go
@@ -1002,26 +1002,34 @@ func (s *standardSchema) getPropertiesColumns() []ColumnDescriptor {
 		valSchema := val.Value
 		if valSchema != nil {
 			// The column's display/DDL name is snake-aliased when the provider opts
-			// in; the wire property name (k) is retained both on the Schema for
-			// response navigation and as the column's wire name so consumers key
-			// data extraction by wire rather than by the snake alias.
+			// in; the wire name (used only to key into the response payload for value
+			// extraction) is the xml: name override when present, otherwise the
+			// original property key. GetName must stay the display name so the
+			// resource-schema and response/select-items descriptors agree - a
+			// divergence creates the column under the wire name on a case-sensitive
+			// backend while the projection references the display name.
 			name := k
 			if snakeAliases {
 				name = casing.ToSnake(k)
 			}
+			colSchema := newSchema(
+				valSchema,
+				s.svc,
+				k,
+				val.Ref,
+			)
+			wireName := k
+			if xmlAlias := colSchema.getXmlAlias(); xmlAlias != "" {
+				wireName = xmlAlias
+			}
 			col := newColumnDescriptorWithWireName(
 				"",
 				name,
-				k,
+				wireName,
 				"",
 				"",
 				nil,
-				newSchema(
-					valSchema,
-					s.svc,
-					k,
-					val.Ref,
-				),
+				colSchema,
 				nil,
 			)
 			cols = append(cols, col)

--- a/internal/anysdk/table.go
+++ b/internal/anysdk/table.go
@@ -175,15 +175,22 @@ func (t *standardTabulation) GetName() string {
 	return t.name
 }
 
+// RenameColumnsToXml records each column's xml: name as its wire name (used to key
+// into the response payload for extraction). It deliberately does NOT touch the
+// display name (GetName): the xml: name is the wire name, not the column name, so
+// the select-items descriptors must keep the same display name as the resource
+// descriptors. Putting the wire name into GetName creates the column under the wire
+// name on a case-sensitive SQL backend while the projection references the display
+// name (42703).
 func (t *standardTabulation) RenameColumnsToXml() Tabulation {
 	for i, v := range t.columns {
 		if v.GetSchema() != nil {
 			alias := v.GetSchema().getXmlAlias()
 			if alias != "" {
-				// standardColumnDescriptor is stored by value, so the rename only
+				// standardColumnDescriptor is stored by value, so the update only
 				// sticks if we write the modified copy back into the slice.
 				if cd, ok := v.(standardColumnDescriptor); ok {
-					cd.Name = alias
+					cd.WireName = alias
 					t.columns[i] = cd
 				}
 			}

--- a/internal/anysdk/xml_wire_name_regression_test.go
+++ b/internal/anysdk/xml_wire_name_regression_test.go
@@ -1,0 +1,105 @@
+package anysdk
+
+import (
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// xmlStringProperty builds a string property carrying an xml: name override (the
+// wire element name), as an xml provider document does for a column whose display
+// name differs from the wire name.
+func xmlStringProperty(xmlName string) *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		Type: "string",
+		XML:  map[string]interface{}{"name": xmlName},
+	}}
+}
+
+// allOfXMLStringProperty builds a property whose xml: name override lives in an
+// allOf member (the shape real provider documents use, e.g. AWS EC2 Volume:
+// allOf: [ {$ref: String}, { xml: { name: availabilityZone } } ]).
+func allOfXMLStringProperty(xmlName string) *openapi3.SchemaRef {
+	return &openapi3.SchemaRef{Value: &openapi3.Schema{
+		AllOf: openapi3.SchemaRefs{
+			{Value: &openapi3.Schema{Type: "string"}},
+			{Value: &openapi3.Schema{XML: map[string]interface{}{"name": xmlName}}},
+		},
+	}}
+}
+
+// assertColumnNaming checks a single column's display name (GetName) and wire name
+// (GetWireName).
+func assertColumnNaming(t *testing.T, cols map[string]ColumnDescriptor, display, wire string) {
+	t.Helper()
+	col, ok := cols[display]
+	if !ok {
+		t.Fatalf("expected a column with display name %q; got %v", display, keysOf(cols))
+	}
+	if got := col.GetName(); got != display {
+		t.Errorf("GetName() = %q, want display name %q", got, display)
+	}
+	if got := col.GetWireName(); got != wire {
+		t.Errorf("column %q: GetWireName() = %q, want wire name %q", display, got, wire)
+	}
+}
+
+// resourceAndSelectItemsCols returns the column descriptors for the two paths a
+// consumer uses: the resource-schema path (plain Tabulate) and the
+// response/select-items path (Tabulate then RenameColumnsToXml, as the XML media
+// type branch does). They must agree on every column's display and wire name.
+func resourceAndSelectItemsCols(s Schema) (resource, selectItems map[string]ColumnDescriptor) {
+	resource = columnsByName(s.Tabulate(false, "").GetColumns())
+	selectItems = columnsByName(s.Tabulate(false, "").RenameColumnsToXml().GetColumns())
+	return resource, selectItems
+}
+
+// TestXMLNameOverrideColumnNaming covers the alpha09 regression (Case A): an xml:
+// name override is the wire name, so it must land in GetWireName and never in
+// GetName, and the resource and response/select-items descriptor paths must agree.
+// Before the fix, RenameColumnsToXml overwrote GetName with the wire name, creating
+// the column under the wire name on a case-sensitive backend (postgres 42703).
+func TestXMLNameOverrideColumnNaming(t *testing.T) {
+	sc := &openapi3.Schema{
+		Type: "object",
+		Properties: openapi3.Schemas{
+			"AvailabilityZone": allOfXMLStringProperty("availabilityZone"), // real allOf shape
+			"SnapshotId":       xmlStringProperty("snapshotId"),            // direct xml shape
+			"name":             stringProperty(),                           // no override: key == wire == display
+		},
+	}
+	svc := &standardService{Provider: &standardProvider{StackQLConfig: &standardStackQLConfig{}}}
+	s := newStandardSchema(sc, svc, "Volume", "")
+
+	resource, selectItems := resourceAndSelectItemsCols(s)
+	for _, cols := range []map[string]ColumnDescriptor{resource, selectItems} {
+		assertColumnNaming(t, cols, "AvailabilityZone", "availabilityZone")
+		assertColumnNaming(t, cols, "SnapshotId", "snapshotId")
+		assertColumnNaming(t, cols, "name", "name") // no-divergence case
+	}
+	if resource["AvailabilityZone"].GetName() != selectItems["AvailabilityZone"].GetName() {
+		t.Errorf("display name diverges across paths: resource %q vs select-items %q",
+			resource["AvailabilityZone"].GetName(), selectItems["AvailabilityZone"].GetName())
+	}
+}
+
+// TestSnakeCaseAliasColumnNamingAcrossPaths covers Case B: under snake_case_aliases
+// the display name is the snake alias and the wire name is the xml: name (the
+// original), consistent across both descriptor paths.
+func TestSnakeCaseAliasColumnNamingAcrossPaths(t *testing.T) {
+	sc := &openapi3.Schema{
+		Type: "object",
+		Properties: openapi3.Schemas{
+			"cidrBlock": xmlStringProperty("cidrBlock"),
+			"VolumeId":  stringProperty(), // snake-aliased, wire == property key
+		},
+	}
+	svc := &standardService{Provider: &standardProvider{StackQLConfig: &standardStackQLConfig{SnakeCaseAliases: true}}}
+	s := newStandardSchema(sc, svc, "Volume", "")
+
+	resource, selectItems := resourceAndSelectItemsCols(s)
+	for _, cols := range []map[string]ColumnDescriptor{resource, selectItems} {
+		assertColumnNaming(t, cols, "cidr_block", "cidrBlock")
+		assertColumnNaming(t, cols, "volume_id", "VolumeId")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes an alpha09 regression: column descriptors from the response/select-items schema path returned GetName() = the WIRE name, while the resource-schema path returned GetName() = the display name. The two diverge for any column whose wire name differs from its display name (xml: name overrides, snake_case_aliases, request.nativeCasing providers). A consumer creates the materialized table from the select-items GetName and projects SELECT * from the resource GetName; the divergence creates the column under the wire name and references the display name, throwing `column "<DisplayName>" does not exist (42703)` on a case-sensitive backend (postgres). sqlite hid it.

Introduced when alpha09 made `RenameColumnsToXml` effective (it was a silent no-op); it began overwriting GetName with the xml: alias.

## Fix
- `RenameColumnsToXml` records the xml: name as the WIRE name (GetWireName), never the display name (GetName).
- `getPropertiesColumns` derives the wire name from the xml: name override when present (else the property key), so GetWireName is correct and identical across the resource and select-items paths.

Contract restored (held in alpha08): GetName() = display/canonical column name (property key, or snake alias when configured) - used for CREATE TABLE/VIEW, projection, output, identical across both descriptor paths. GetWireName() = the foreign-API wire name (xml: name, or the original under snake_case_aliases) - used only to key into the response payload; defaults to GetName when there is no distinct wire name.

## Tests
White-box unit tests asserting GetName == display and GetWireName == wire across BOTH descriptor paths for: xml: name override (real allOf shape and direct xml:), snake_case_aliases, and a no-divergence case. Verified to fail without the fix and pass with it.

## Verification
go build ./..., go test ./..., gofmt, golangci-lint all clean.