### PR TITLE
fix: casing-surface parity + schema-driven XML walker gaps from AWS p…

### DIFF
--- a/internal/anysdk/casing_surface_regression_test.go
+++ b/internal/anysdk/casing_surface_regression_test.go
@@ -1,0 +1,246 @@
+package anysdk
+
+import (
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/stackql/any-sdk/pkg/casing"
+
+	"gotest.tools/assert"
+)
+
+// These tests cover the casing-surface parity fixes shaken out by live AWS
+// provider lifecycle testing: every column-naming path (SELECT tabulation,
+// SELECT * star expansion, DESCRIBE) and every parameter-resolution path
+// (method routing, request construction) must agree on the snake alias
+// treatment, and request bodies must only hit the wire when they exist.
+
+func snakeAliasedObjectSchema(flagOn bool, propNames ...string) Schema {
+	prov := &standardProvider{StackQLConfig: &standardStackQLConfig{SnakeCaseAliases: flagOn}}
+	svc := &standardService{Provider: prov}
+	props := openapi3.Schemas{}
+	for _, p := range propNames {
+		props[p] = stringProperty()
+	}
+	sc := &openapi3.Schema{Type: "object", Properties: props}
+	return newStandardSchema(sc, svc, "Row", "")
+}
+
+// TestToDescriptionMapSnakeAliases: DESCRIBE surfaces the same column names as
+// SELECT. Before the fix, DESCRIBE showed wire casing (volumeId) while SELECT
+// projected the snake alias (volume_id).
+func TestToDescriptionMapSnakeAliases(t *testing.T) {
+	s := snakeAliasedObjectSchema(true, "VpcId", "cidrBlock", "state")
+	dm := s.ToDescriptionMap(true)
+	for _, want := range []string{"vpc_id", "cidr_block", "state"} {
+		entry, ok := dm[want]
+		if !ok {
+			t.Fatalf("expected DESCRIBE column %q; got %v", want, mapKeys(dm))
+		}
+		entryMap, isMap := entry.(map[string]interface{})
+		if !isMap {
+			t.Fatalf("description entry for %q is not a map: %T", want, entry)
+		}
+		if got := entryMap["name"]; got != want {
+			t.Errorf("description entry name = %v, want %q", got, want)
+		}
+	}
+	for _, wire := range []string{"VpcId", "cidrBlock"} {
+		if _, present := dm[wire]; present {
+			t.Errorf("wire-cased key %q must not appear in DESCRIBE output", wire)
+		}
+	}
+}
+
+// TestToDescriptionMapDisabledIsWireKeyed: default behaviour unchanged.
+func TestToDescriptionMapDisabledIsWireKeyed(t *testing.T) {
+	s := snakeAliasedObjectSchema(false, "VpcId", "cidrBlock")
+	dm := s.ToDescriptionMap(false)
+	for _, wire := range []string{"VpcId", "cidrBlock"} {
+		if _, ok := dm[wire]; !ok {
+			t.Errorf("expected wire-cased DESCRIBE key %q; got %v", wire, mapKeys(dm))
+		}
+	}
+}
+
+// TestGetAllColumnsSnakeAliases: SELECT * star expansion surfaces snake aliases.
+// Before the fix, star expansion emitted wire-cased identifiers which a
+// case-sensitive backend resolved as string literals - every value projected
+// as its own column name.
+func TestGetAllColumnsSnakeAliases(t *testing.T) {
+	s := snakeAliasedObjectSchema(true, "VpcId", "cidrBlock", "state")
+	got := stringSet(s.GetAllColumns(""))
+	for _, want := range []string{"vpc_id", "cidr_block", "state"} {
+		if _, ok := got[want]; !ok {
+			t.Errorf("expected star column %q; got %v", want, got)
+		}
+	}
+	if _, present := got["VpcId"]; present {
+		t.Errorf("wire-cased star column VpcId must not appear: %v", got)
+	}
+}
+
+// TestGetAllColumnsDisabledIsWireKeyed: default behaviour unchanged.
+func TestGetAllColumnsDisabledIsWireKeyed(t *testing.T) {
+	s := snakeAliasedObjectSchema(false, "VpcId", "cidrBlock")
+	got := stringSet(s.GetAllColumns(""))
+	for _, wire := range []string{"VpcId", "cidrBlock"} {
+		if _, ok := got[wire]; !ok {
+			t.Errorf("expected wire-cased star column %q; got %v", wire, got)
+		}
+	}
+}
+
+func requiredQueryParameterRef(name string) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{Value: &openapi3.Parameter{
+		Name: name, In: openapi3.ParameterInQuery, Required: true,
+	}}
+}
+
+func newRequiredParamOperationStore(nativeCasing string) *standardOpenAPIOperationStore {
+	op := &standardOpenAPIOperationStore{
+		OperationRef: &OperationRef{Value: &openapi3.Operation{
+			Parameters: openapi3.Parameters{requiredQueryParameterRef("VpcId")},
+		}},
+	}
+	if nativeCasing != "" {
+		op.Request = &standardExpectedRequest{NativeCasing: nativeCasing}
+	}
+	return op
+}
+
+// TestParameterMatchReverseCasing: a snake_case SQL key must satisfy its
+// wire-name REQUIRED parameter during method routing. Before the fix,
+// `DELETE ... WHERE vpc_id = ...` reported "no appropriate method" even though
+// the casing engine could resolve vpc_id -> VpcId at request-build time.
+func TestParameterMatchReverseCasing(t *testing.T) {
+	op := newRequiredParamOperationStore(casing.Pascal)
+	remaining, ok := op.parameterMatch(map[string]interface{}{"vpc_id": "vpc-1"})
+	if !ok {
+		t.Fatalf("snake key vpc_id should satisfy required wire param VpcId")
+	}
+	if len(remaining) != 0 {
+		t.Errorf("matched snake key should be consumed; remaining = %v", remaining)
+	}
+	// The wire form must still match too.
+	if _, ok := op.parameterMatch(map[string]interface{}{"VpcId": "vpc-1"}); !ok {
+		t.Errorf("wire key VpcId must still satisfy its own parameter")
+	}
+	// namespaceParameterMatch shares the semantics.
+	if _, ok := op.namespaceParameterMatch(map[string]interface{}{"vpc_id": "vpc-1"}); !ok {
+		t.Errorf("namespaceParameterMatch must accept the snake alias too")
+	}
+}
+
+// TestParameterMatchReverseCasingAbsentIsUnchanged: without request
+// nativeCasing a snake key does NOT satisfy the wire param (no behaviour change
+// for providers that have not opted in).
+func TestParameterMatchReverseCasingAbsentIsUnchanged(t *testing.T) {
+	op := newRequiredParamOperationStore("")
+	if _, ok := op.parameterMatch(map[string]interface{}{"vpc_id": "vpc-1"}); ok {
+		t.Fatalf("snake key must not satisfy wire param absent nativeCasing")
+	}
+}
+
+// TestGetOperationParameterReverseCasing: request construction resolves a
+// snake key to its wire-name operation parameter, returning the Addressable
+// under its wire name (HttpParameters.StoreParameter then re-keys the value to
+// the wire form). Before the fix, the value fell through to the server-param
+// branch and never reached the wire ("The request must contain the parameter
+// vpcId").
+func TestGetOperationParameterReverseCasing(t *testing.T) {
+	op := newRequiredParamOperationStore(casing.Pascal)
+	addr, ok := op.GetOperationParameter("vpc_id")
+	if !ok {
+		t.Fatalf("expected vpc_id to resolve to the VpcId operation parameter")
+	}
+	if got := addr.GetName(); got != "VpcId" {
+		t.Errorf("resolved Addressable name = %q, want wire name VpcId", got)
+	}
+	// Absent native casing, unchanged.
+	opPlain := newRequiredParamOperationStore("")
+	if _, ok := opPlain.GetOperationParameter("vpc_id"); ok {
+		t.Errorf("snake key must not resolve absent nativeCasing")
+	}
+}
+
+// TestParameterizeNilBodySendsNoBody: a nil body must not marshal to literal
+// "null" bytes (S3 CreateBucket rejects them with MalformedXML).
+func TestParameterizeNilBodySendsNoBody(t *testing.T) {
+	setupFileRoot(t)
+	ops, svc := loadK8sNodeSelectOp(t)
+	ops.setRequest(&standardExpectedRequest{BodyMediaType: "application/json"})
+
+	params := NewHttpParameters(ops)
+	err := params.IngestMap(map[string]interface{}{"cluster_addr": "k8shost"})
+	assert.NilError(t, err)
+
+	rvi, err := ops.parameterize(dummmyK8sProv, svc, params, nil)
+	assert.NilError(t, err)
+	assert.Assert(t, rvi != nil)
+	if rvi.Request.Body != nil {
+		b, _ := io.ReadAll(rvi.Request.Body)
+		t.Fatalf("nil body must not produce request bytes; got %q", string(b))
+	}
+}
+
+// TestParameterizeBaseFallbackBody: with request.base declared, an empty body
+// map sends the base bytes verbatim with the declared Content-Type (AWS json
+// requires literal '{}' on no-input ops).
+func TestParameterizeBaseFallbackBody(t *testing.T) {
+	setupFileRoot(t)
+	ops, svc := loadK8sNodeSelectOp(t)
+	ops.setRequest(&standardExpectedRequest{
+		BodyMediaType: "application/x-amz-json-1.0",
+		Base:          "{}",
+	})
+
+	params := NewHttpParameters(ops)
+	err := params.IngestMap(map[string]interface{}{"cluster_addr": "k8shost"})
+	assert.NilError(t, err)
+
+	rvi, err := ops.parameterize(dummmyK8sProv, svc, params, map[string]interface{}{})
+	assert.NilError(t, err)
+	assert.Assert(t, rvi != nil)
+	assert.Assert(t, rvi.Request.Body != nil)
+	b, _ := io.ReadAll(rvi.Request.Body)
+	if string(b) != "{}" {
+		t.Fatalf("base fallback body = %q, want {}", string(b))
+	}
+	if got := rvi.Request.Header.Get("Content-Type"); got != "application/x-amz-json-1.0" {
+		t.Errorf("Content-Type = %q, want application/x-amz-json-1.0", got)
+	}
+}
+
+func loadK8sNodeSelectOp(t *testing.T) (StandardOperationStore, Service) {
+	t.Helper()
+	b, err := GetServiceDocBytes(fmt.Sprintf("k8s/%s/services/core_v1.yaml", "v0.1.0"), "")
+	assert.NilError(t, err)
+	l := newLoader()
+	svc, err := l.loadFromBytes(b)
+	assert.NilError(t, err)
+	rsc, err := svc.GetResource("node")
+	assert.NilError(t, err)
+	ops, _, ok := rsc.GetFirstNamespaceMethodMatchFromSQLVerb("select", nil)
+	assert.Assert(t, ok)
+	return ops, svc
+}
+
+func mapKeys(m map[string]interface{}) []string {
+	rv := make([]string, 0, len(m))
+	for k := range m {
+		rv = append(rv, k)
+	}
+	return rv
+}
+
+func stringSet(ss []string) map[string]struct{} {
+	rv := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		rv[s] = struct{}{}
+	}
+	return rv
+}

--- a/internal/anysdk/casing_surface_regression_test.go
+++ b/internal/anysdk/casing_surface_regression_test.go
@@ -215,6 +215,37 @@ func TestParameterizeBaseFallbackBody(t *testing.T) {
 	}
 }
 
+// TestParameterizeTransformExpandsForEmptyBody: a declared request transform
+// generates wire bytes even when no body params are supplied (the aws ec2
+// "no request body parameters still expands template" fixture behaviour) -
+// the empty-body skip applies only to plain marshalled bodies.
+func TestParameterizeTransformExpandsForEmptyBody(t *testing.T) {
+	setupFileRoot(t)
+	ops, svc := loadK8sNodeSelectOp(t)
+	ops.setRequest(&standardExpectedRequest{
+		BodyMediaType: "application/x-www-form-urlencoded",
+		Transform: &standardTransform{
+			Type: "golang_template_text_v0.1.0",
+			Body: "Action=DescribeVolumes&Version=2016-11-15",
+		},
+	})
+
+	for _, body := range []interface{}{nil, map[string]interface{}{}} {
+		params := NewHttpParameters(ops)
+		err := params.IngestMap(map[string]interface{}{"cluster_addr": "k8shost"})
+		assert.NilError(t, err)
+
+		rvi, err := ops.parameterize(dummmyK8sProv, svc, params, body)
+		assert.NilError(t, err)
+		assert.Assert(t, rvi != nil)
+		assert.Assert(t, rvi.Request.Body != nil)
+		b, _ := io.ReadAll(rvi.Request.Body)
+		if string(b) != "Action=DescribeVolumes&Version=2016-11-15" {
+			t.Fatalf("transform must expand for empty body (%T); got %q", body, string(b))
+		}
+	}
+}
+
 func loadK8sNodeSelectOp(t *testing.T) (StandardOperationStore, Service) {
 	t.Helper()
 	b, err := GetServiceDocBytes(fmt.Sprintf("k8s/%s/services/core_v1.yaml", "v0.1.0"), "")

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -740,6 +740,7 @@ func (op *standardOpenAPIOperationStore) parameterMatch(params map[string]interf
 		}
 		optionalParameters.Put(key, vOpt)
 	}
+	nc := op.GetRequestNativeCasing()
 	for k := range copiedParams {
 		if requiredParameters.Delete(k) {
 			delete(copiedParams, k)
@@ -748,6 +749,21 @@ func (op *standardOpenAPIOperationStore) parameterMatch(params map[string]interf
 		if optionalParameters.Delete(k) {
 			delete(copiedParams, k)
 			continue
+		}
+		// Reverse-casing retry: a snake_case SQL key satisfies its wire-name
+		// parameter when the method declares a native request casing
+		// (mirrors GetParameter). Absent native casing this is a no-op.
+		if nc != "" {
+			if wireKey := casing.FromSnake(k, nc); wireKey != k {
+				if requiredParameters.Delete(wireKey) {
+					delete(copiedParams, k)
+					continue
+				}
+				if optionalParameters.Delete(wireKey) {
+					delete(copiedParams, k)
+					continue
+				}
+			}
 		}
 		// log.Debugf("parameter '%s' unmatched for method '%s'\n", k, op.getName())
 	}
@@ -781,6 +797,7 @@ func (op *standardOpenAPIOperationStore) namespaceParameterMatch(params map[stri
 		}
 		optionalParameters.Put(key, vOpt)
 	}
+	nc := op.GetRequestNativeCasing()
 	for k := range copiedParams {
 		if requiredParameters.Delete(k) {
 			delete(copiedParams, k)
@@ -789,6 +806,21 @@ func (op *standardOpenAPIOperationStore) namespaceParameterMatch(params map[stri
 		if optionalParameters.Delete(k) {
 			delete(copiedParams, k)
 			continue
+		}
+		// Reverse-casing retry: a snake_case SQL key satisfies its wire-name
+		// parameter when the method declares a native request casing
+		// (mirrors GetParameter). Absent native casing this is a no-op.
+		if nc != "" {
+			if wireKey := casing.FromSnake(k, nc); wireKey != k {
+				if requiredParameters.Delete(wireKey) {
+					delete(copiedParams, k)
+					continue
+				}
+				if optionalParameters.Delete(wireKey) {
+					delete(copiedParams, k)
+					continue
+				}
+			}
 		}
 		// log.Debugf("parameter '%s' unmatched for method '%s'\n", k, op.getName())
 	}
@@ -1444,6 +1476,24 @@ func (op *standardOpenAPIOperationStore) GetOperationParameters() Params {
 }
 
 func (op *standardOpenAPIOperationStore) GetOperationParameter(key string) (Addressable, bool) {
+	rv, ok := op.getOperationParameterByWireKey(key)
+	if ok {
+		return rv, true
+	}
+	// Reverse-casing retry: a snake_case SQL key resolves to its wire-name
+	// operation parameter when the method declares a native request casing
+	// (mirrors GetParameter / parameterMatch). The returned Addressable
+	// carries the wire name, so HttpParameters.StoreParameter re-keys the
+	// value to the wire form for request construction.
+	if nc := op.GetRequestNativeCasing(); nc != "" {
+		if wireKey := casing.FromSnake(key, nc); wireKey != key {
+			return op.getOperationParameterByWireKey(wireKey)
+		}
+	}
+	return nil, false
+}
+
+func (op *standardOpenAPIOperationStore) getOperationParameterByWireKey(key string) (Addressable, bool) {
 	paramLocal, isParamLocal := op.Parameters[key]
 	if isParamLocal {
 		b, err := json.Marshal(paramLocal)
@@ -1640,21 +1690,27 @@ func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc S
 	}
 	contentTypeHeaderRequired := false
 	var bodyReader io.Reader
-	if op.Request != nil {
+	// Marshal a request body only when there is body content to send. A nil
+	// or empty body must not marshal - the bytes would be literal "null" /
+	// "{}" on ops that expect no body at all (e.g. S3 CreateBucket rejects
+	// them with MalformedXML). Protocols that require a body even for empty
+	// inputs (AWS json wants literal "{}") declare request.base, which is
+	// sent verbatim as the fallback.
+	if op.Request != nil && hasRequestBodyContent(requestBody) {
 		// TODO: transform
 		marshalledBody := op.marshalBody(requestBody, op.Request)
 		b := marshalledBody.GetBytes()
 		marshalledBodyErr, hassError := marshalledBody.GetError()
 		if hassError {
-			// A request block may be declared purely to carry metadata (e.g.
-			// request.nativeCasing on a body-less GET). With no body content to
-			// marshal there is no media type to resolve, so a marshalling error is
-			// only fatal when there is actually a body to send.
-			if hasRequestBodyContent(requestBody) {
-				return nil, marshalledBodyErr
-			}
-		} else if len(b) > 0 {
+			return nil, marshalledBodyErr
+		}
+		if len(b) > 0 {
 			bodyReader = bytes.NewReader(b)
+			contentTypeHeaderRequired = true
+		}
+	} else if op.Request != nil {
+		if baseBytes := op.getBaseRequestBodyBytes(); len(baseBytes) > 0 {
+			bodyReader = bytes.NewReader(baseBytes)
 			contentTypeHeaderRequired = true
 		}
 	}
@@ -1677,7 +1733,10 @@ func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc S
 		return nil, err
 	}
 	if contentTypeHeaderRequired {
-		if prefilledHeader.Get("Content-Type") != "" {
+		// Fill Content-Type from the declared request media type unless a
+		// header parameter already supplied one. (Downstream armoury header
+		// merging may overwrite with the same declared value.)
+		if prefilledHeader.Get("Content-Type") == "" && op.Request.BodyMediaType != "" {
 			prefilledHeader.Set("Content-Type", op.Request.BodyMediaType)
 		}
 	}
@@ -2014,6 +2073,10 @@ func (a xmlSchemaAdapter) Properties() map[string]stream_transform.SchemaTree {
 		out[k] = xmlSchemaAdapter{s: v}
 	}
 	return out
+}
+
+func (a xmlSchemaAdapter) XMLName() string {
+	return a.s.getXmlAlias()
 }
 
 func (op *standardOpenAPIOperationStore) ProcessResponse(httpResponse *http.Response) (ProcessedOperationResponse, error) {

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -1690,26 +1690,40 @@ func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc S
 	}
 	contentTypeHeaderRequired := false
 	var bodyReader io.Reader
-	// Marshal a request body only when there is body content to send. A nil
-	// or empty body must not marshal - the bytes would be literal "null" /
-	// "{}" on ops that expect no body at all (e.g. S3 CreateBucket rejects
-	// them with MalformedXML). Protocols that require a body even for empty
-	// inputs (AWS json wants literal "{}") declare request.base, which is
-	// sent verbatim as the fallback.
-	if op.Request != nil && hasRequestBodyContent(requestBody) {
-		// TODO: transform
-		marshalledBody := op.marshalBody(requestBody, op.Request)
-		b := marshalledBody.GetBytes()
-		marshalledBodyErr, hassError := marshalledBody.GetError()
-		if hassError {
-			return nil, marshalledBodyErr
-		}
-		if len(b) > 0 {
-			bodyReader = bytes.NewReader(b)
-			contentTypeHeaderRequired = true
-		}
-	} else if op.Request != nil {
-		if baseBytes := op.getBaseRequestBodyBytes(); len(baseBytes) > 0 {
+	// Marshal a request body only when there is something to send:
+	//   - A declared request TRANSFORM always runs - templates generate wire
+	//     bytes (e.g. "Action=DescribeVolumes&Version=...") even from an
+	//     empty body map.
+	//   - Otherwise a nil or empty body must not marshal: the bytes would be
+	//     literal "null" / "{}" on ops that expect no body at all (e.g. S3
+	//     CreateBucket rejects them with MalformedXML).
+	//   - Protocols that require a body even for empty inputs (AWS json
+	//     wants literal "{}") declare request.base, sent verbatim as the
+	//     fallback.
+	if op.Request != nil {
+		_, hasTransform := op.Request.GetTransform()
+		if hasTransform || hasRequestBodyContent(requestBody) {
+			effectiveBody := requestBody
+			if util.IsNil(effectiveBody) {
+				// Transforms consume a map; normalise a nil interface so the
+				// template still expands (matching an empty SQL input).
+				effectiveBody = map[string]interface{}{}
+			}
+			marshalledBody := op.marshalBody(effectiveBody, op.Request)
+			b := marshalledBody.GetBytes()
+			marshalledBodyErr, hassError := marshalledBody.GetError()
+			if hassError {
+				// A marshalling error is only fatal when there is actual body
+				// content to send; a transform over an empty body that cannot
+				// resolve simply sends nothing.
+				if hasRequestBodyContent(requestBody) {
+					return nil, marshalledBodyErr
+				}
+			} else if len(b) > 0 {
+				bodyReader = bytes.NewReader(b)
+				contentTypeHeaderRequired = true
+			}
+		} else if baseBytes := op.getBaseRequestBodyBytes(); len(baseBytes) > 0 {
 			bodyReader = bytes.NewReader(baseBytes)
 			contentTypeHeaderRequired = true
 		}

--- a/internal/anysdk/schema.go
+++ b/internal/anysdk/schema.go
@@ -968,9 +968,17 @@ func (s *standardSchema) GetAllColumns(defaultColName string) []string {
 	var retVal []string
 	properties := s.getProperties()
 	if s.Type == "object" || (len(properties) > 0) {
+		// Star expansion surfaces the same column names as the resource
+		// tabulation and DESCRIBE: snake aliases when the provider opts in
+		// (mirrors getPropertiesColumns / ToDescriptionMap).
+		snakeAliases := s.isSnakeCaseAliasesEnabled()
 		for k, val := range properties {
 			_, valSchemaExists := val.getOpenapiSchema()
 			if valSchemaExists {
+				if snakeAliases {
+					retVal = append(retVal, casing.ToSnake(k))
+					continue
+				}
 				retVal = append(retVal, k)
 			}
 		}
@@ -1302,13 +1310,21 @@ func (s *standardSchema) ToDescriptionMap(extended bool) map[string]interface{} 
 	// TODO:
 	//     - Ensure this logic conforms to openapi3 doc rules.
 	//     - Add integration testing to ensure same, corner cases.
+	// DESCRIBE surfaces the same column names as SELECT: when the provider
+	// opts in to snake_case_aliases, the display/DDL name is the snake alias
+	// of the wire property key (mirrors getPropertiesColumns).
+	snakeAliases := s.isSnakeCaseAliasesEnabled()
 	if s.Type == "object" {
 		for k, v := range s.Properties {
 			p := v.Value
 			if p != nil {
 				pm := newSchema(p, s.svc, "", v.Ref).toFlatDescriptionMap(extended)
-				pm["name"] = k
-				retVal[k] = pm
+				name := k
+				if snakeAliases {
+					name = casing.ToSnake(k)
+				}
+				pm["name"] = name
+				retVal[name] = pm
 			}
 		}
 		return retVal
@@ -1319,8 +1335,12 @@ func (s *standardSchema) ToDescriptionMap(extended bool) map[string]interface{} 
 			p := v.Value
 			if p != nil {
 				pm := newSchema(p, s.svc, "", v.Ref).toFlatDescriptionMap(extended)
-				pm["name"] = k
-				retVal[k] = pm
+				name := k
+				if snakeAliases {
+					name = casing.ToSnake(k)
+				}
+				pm["name"] = name
+				retVal[name] = pm
 			}
 		}
 		return retVal

--- a/pkg/stream_transform/schema_driven_xml.go
+++ b/pkg/stream_transform/schema_driven_xml.go
@@ -34,8 +34,11 @@ type SchemaTree interface {
 	Items() (SchemaTree, bool)
 	// Property returns the named child property schema for an object node.
 	Property(name string) (SchemaTree, bool)
-	// Properties returns all child property schemas keyed by their wire name.
+	// Properties returns all child property schemas keyed by their property name.
 	Properties() map[string]SchemaTree
+	// XMLName returns the xml: name override (the wire element name) when the
+	// property's wire name differs from its property name, else "".
+	XMLName() string
 }
 
 // schemaDrivenXMLTransformer walks one XML body into stackql's
@@ -84,6 +87,11 @@ func (t *schemaDrivenXMLTransformer) Transform() error {
 	rowSchema, err := t.rowSchema()
 	if err != nil {
 		return err
+	}
+	// An empty response body (e.g. S3 CreateBucket returns 200 with headers
+	// only) is a legitimate no-rows outcome, not a transform failure.
+	if strings.TrimSpace(t.input) == "" {
+		return t.write(make([]interface{}, 0))
 	}
 	// Decode WITHOUT mxj casting so leaf values stay strings; the schema's declared
 	// type is then authoritative (this is what stops 12-digit IDs becoming float64).
@@ -149,6 +157,17 @@ func extractRows(payload map[string]interface{}, rowSchema SchemaTree) []map[str
 		// The payload itself carries the row's fields -> singleton response.
 		return []map[string]interface{}{payload}
 	}
+	// Singleton-unwrap: a named wrapper member carries the row (CreateVpc ->
+	// {vpc: {...}}, GetUser -> {User: {...}}). Checked before list detection
+	// so an ancillary list sibling (GetHostedZone's VPCs) cannot hijack the
+	// row. Deterministic key order.
+	for _, k := range sortedKeys(payload) {
+		if mm, ok := payload[k].(map[string]interface{}); ok {
+			if mapHasAnyKey(mm, rowProps) {
+				return []map[string]interface{}{mm}
+			}
+		}
+	}
 	member, ok := findListMember(payload)
 	if !ok {
 		return nil
@@ -159,14 +178,29 @@ func extractRows(payload map[string]interface{}, rowSchema SchemaTree) []map[str
 func projectRow(row map[string]interface{}, rowSchema SchemaTree) map[string]interface{} {
 	out := make(map[string]interface{}, len(rowSchema.Properties()))
 	for name, propSchema := range rowSchema.Properties() {
-		raw, ok := row[name]
+		// The XML element name is the xml: name override when present (a
+		// property whose display name differs from the wire name, e.g. EC2's
+		// Attachments member serialised as <attachmentSet>), else the property
+		// name itself. The projected row is keyed by the wire name - value
+		// extraction downstream resolves GetWireName first, then GetName.
+		key := wireKey(name, propSchema)
+		raw, ok := row[key]
 		if !ok {
-			out[name] = nil
+			out[key] = nil
 			continue
 		}
-		out[name] = convertValue(raw, propSchema.Type())
+		out[key] = convertValue(raw, propSchema.Type())
 	}
 	return out
+}
+
+// wireKey resolves the XML element name for a property: the xml: name override
+// when declared, else the property name.
+func wireKey(name string, propSchema SchemaTree) string {
+	if xn := propSchema.XMLName(); xn != "" {
+		return xn
+	}
+	return name
 }
 
 // convertValue applies the schema-declared type to a (string-typed) mxj leaf value.
@@ -210,6 +244,15 @@ func convertValue(raw interface{}, schemaType string) interface{} {
 		if s, ok := raw.(string); ok {
 			return s
 		}
+		// A complex value under a string-typed schema (e.g. a Display column
+		// that stringifies a nested structure for JSON_EXTRACT decomposition)
+		// must serialise as JSON, never as Go's fmt map representation.
+		switch raw.(type) {
+		case map[string]interface{}, []interface{}:
+			if b, err := json.Marshal(raw); err == nil {
+				return string(b)
+			}
+		}
 		return fmt.Sprintf("%v", raw)
 	default:
 		return raw
@@ -239,8 +282,8 @@ func resultWrapper(m map[string]interface{}) (map[string]interface{}, bool) {
 }
 
 func mapHasAnyKey(m map[string]interface{}, props map[string]SchemaTree) bool {
-	for k := range props {
-		if _, ok := m[k]; ok {
+	for k, p := range props {
+		if _, ok := m[wireKey(k, p)]; ok {
 			return true
 		}
 	}

--- a/pkg/stream_transform/schema_driven_xml_test.go
+++ b/pkg/stream_transform/schema_driven_xml_test.go
@@ -9,12 +9,15 @@ import (
 
 // fakeSchema is a minimal SchemaTree for tests.
 type fakeSchema struct {
-	typ   string
-	items *fakeSchema
-	props map[string]*fakeSchema
+	typ     string
+	items   *fakeSchema
+	props   map[string]*fakeSchema
+	xmlName string
 }
 
 func (f *fakeSchema) Type() string { return f.typ }
+
+func (f *fakeSchema) XMLName() string { return f.xmlName }
 
 func (f *fakeSchema) Items() (SchemaTree, bool) {
 	if f.items == nil {
@@ -182,6 +185,93 @@ func TestWalker_TypeDispatch(t *testing.T) {
 	}
 	if r["Tags"] != nil {
 		t.Errorf("Tags (self-closing) = %#v, want null", r["Tags"])
+	}
+}
+
+func TestWalker_XMLNameOverrideProjection(t *testing.T) {
+	// EC2's Volume.Attachments member is serialised as <attachmentSet>: the
+	// schema carries the member name as the property key and the wire element
+	// name as an xml: name override. The walker must extract by the override
+	// and key the projected row by it (value extraction downstream resolves
+	// GetWireName first).
+	row := &fakeSchema{typ: "object", props: map[string]*fakeSchema{
+		"VolumeId":    {typ: "string", xmlName: "volumeId"},
+		"Attachments": {typ: "array", xmlName: "attachmentSet"},
+		"Size":        {typ: "integer", xmlName: "size"},
+	}}
+	list := &fakeSchema{typ: "array", items: row}
+	override := &fakeSchema{typ: "object", props: map[string]*fakeSchema{"line_items": list}}
+	xml := `<DescribeVolumesResponse><volumeSet>` +
+		`<item><volumeId>vol-1</volumeId><size>8</size>` +
+		`<attachmentSet><item><instanceId>i-1</instanceId></item></attachmentSet></item>` +
+		`</volumeSet></DescribeVolumesResponse>`
+	rows := runWalker(t, override, XProtocolEC2, xml)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d (%v)", len(rows), rows)
+	}
+	r := rows[0]
+	if r["volumeId"] != "vol-1" || r["size"] != float64(8) {
+		t.Fatalf("scalar wire-key projection mismatch: %v", r)
+	}
+	att, ok := r["attachmentSet"].(string)
+	if !ok || !bytes.Contains([]byte(att), []byte("i-1")) {
+		t.Fatalf("attachmentSet should be a JSON string containing i-1: %v", r["attachmentSet"])
+	}
+	if _, present := r["Attachments"]; present {
+		t.Fatalf("projected row must be keyed by wire name, not property name: %v", r)
+	}
+}
+
+func TestWalker_ComplexValueUnderStringSchemaIsJSON(t *testing.T) {
+	// Display schemas type complex columns as "string" so users decompose
+	// them with JSON_EXTRACT. A nested XML structure landing under such a
+	// column must serialise as JSON, not Go fmt map notation.
+	override := overrideWith(map[string]string{"AttributeName": "string", "AttributeValues": "string"})
+	xml := `<DescribeAccountAttributesResponse><accountAttributeSet>` +
+		`<item><AttributeName>max-instances</AttributeName>` +
+		`<AttributeValues><item><attributeValue>20</attributeValue></item></AttributeValues></item>` +
+		`</accountAttributeSet></DescribeAccountAttributesResponse>`
+	rows := runWalker(t, override, XProtocolEC2, xml)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 row, got %d (%v)", len(rows), rows)
+	}
+	av, ok := rows[0]["AttributeValues"].(string)
+	if !ok {
+		t.Fatalf("AttributeValues should be a string: %#v", rows[0]["AttributeValues"])
+	}
+	var decoded map[string]interface{}
+	if err := json.Unmarshal([]byte(av), &decoded); err != nil {
+		t.Fatalf("AttributeValues should be valid JSON, got %q: %v", av, err)
+	}
+	if !bytes.Contains([]byte(av), []byte(`"attributeValue"`)) {
+		t.Fatalf("expected attributeValue key in JSON: %q", av)
+	}
+}
+
+func TestWalker_EC2SingletonUnwrap(t *testing.T) {
+	// CreateVpc (ec2 protocol) returns {requestId, vpc: {...}} - the row lives
+	// under a named wrapper member. The walker must unwrap one level when the
+	// payload root does not itself carry the row fields.
+	override := overrideWith(map[string]string{"vpcId": "string", "state": "string", "cidrBlock": "string"})
+	xml := `<CreateVpcResponse><requestId>r-9</requestId>` +
+		`<vpc><vpcId>vpc-123</vpcId><state>pending</state><cidrBlock>10.99.0.0/16</cidrBlock></vpc>` +
+		`</CreateVpcResponse>`
+	rows := runWalker(t, override, XProtocolEC2, xml)
+	if len(rows) != 1 {
+		t.Fatalf("want 1 unwrapped singleton row, got %d (%v)", len(rows), rows)
+	}
+	if rows[0]["vpcId"] != "vpc-123" || rows[0]["cidrBlock"] != "10.99.0.0/16" {
+		t.Fatalf("unwrap mismatch: %v", rows[0])
+	}
+}
+
+func TestWalker_EmptyBodyYieldsNoRows(t *testing.T) {
+	// S3 CreateBucket (and friends) return 200 with an empty body; the walker
+	// must emit an empty row set rather than an mxj EOF error.
+	override := overrideWith(map[string]string{"Location": "string"})
+	rows := runWalker(t, override, XProtocolRestXML, "")
+	if len(rows) != 0 {
+		t.Fatalf("want 0 rows for empty body, got %d (%v)", len(rows), rows)
 	}
 }
 


### PR DESCRIPTION
…rovider e2e

Shaken out by live AWS provider lifecycle testing (INSERT/SELECT/UPDATE/DELETE across ec2, query, aws-json and rest-xml protocols):

Casing-surface parity (snake_case_aliases must agree on every path):
- ToDescriptionMap: DESCRIBE now renders snake aliases (was wire casing).
- GetAllColumns: SELECT * star expansion now renders snake aliases (wire-cased identifiers resolved as string literals on case-sensitive backends - every value projected as its own column name).
- parameterMatch / namespaceParameterMatch: snake keys satisfy REQUIRED wire params during method routing (was "no appropriate method" for DELETE ... WHERE vpc_id = ...).
- GetOperationParameter: snake keys resolve to wire-name operation params at request build, so values reach the wire under the wire name.

schema_driven_xml walker:
- SchemaTree.XMLName(): rows extract by the xml: name override (member-name properties with locationName wire elements - the AWS provider shape); projected rows keyed by wire name for GetWireName-first value extraction.
- Complex values under string-typed columns serialise as JSON, not Go map notation (JSON_EXTRACT-able).
- Singleton-unwrap regime: CreateVpc-style {vpc: {...}} wrappers project (makes INSERT ... RETURNING work).
- Empty 200 bodies (S3 CreateBucket) yield zero rows, not an mxj EOF error.

Request construction (parameterize):
- Nil/empty bodies no longer marshal (literal "null" bytes tripped S3 MalformedXML); request.base bytes are sent verbatim as the fallback body (AWS json requires literal "{}" on no-input ops).
- Content-Type stanza condition was inverted (only set the header when it was already set); now fills from the declared request media type.

All behaviours regression-tested; absent the opt-in flags every change is a no-op.