### PR TITLE
fix(request): no dangling ? on empty query strings; feat(auth): doc-level OCI env var indirections

### DIFF
--- a/internal/anysdk/auth_dto.go
+++ b/internal/anysdk/auth_dto.go
@@ -43,6 +43,13 @@ type AuthDTO interface {
 	GetAuthStyle() int
 	GetAccountID() string
 	GetAccountIDEnvVar() string
+	GetOciTenancyOCIDEnvVar() string
+	GetOciUserOCIDEnvVar() string
+	GetOciFingerprintEnvVar() string
+	GetOciPrivateKeyEnvVar() string
+	GetOciPrivateKeyPathEnvVar() string
+	GetOciPassphraseEnvVar() string
+	GetOciRegionEnvVar() string
 }
 
 type standardAuthDTO struct {
@@ -76,6 +83,46 @@ type standardAuthDTO struct {
 	AuthStyle          int              `json:"auth_style" yaml:"auth_style"`
 	AccoountID         string           `json:"account_id" yaml:"account_id"`
 	AccountIDEnvVar    string           `json:"account_id_env_var" yaml:"account_id_var"`
+	// OCI signing (oci_signing_v1) doc-level env var indirections: a provider
+	// doc may ship default env var names so that a populated environment
+	// needs no runtime auth context at all. Only indirections are accepted
+	// at doc level - literal credential values belong exclusively in the
+	// runtime auth context.
+	OciTenancyOCIDEnvVar    string `json:"tenancy_ocid_envvar,omitempty" yaml:"tenancy_ocid_envvar,omitempty"`
+	OciUserOCIDEnvVar       string `json:"user_ocid_envvar,omitempty" yaml:"user_ocid_envvar,omitempty"`
+	OciFingerprintEnvVar    string `json:"fingerprint_envvar,omitempty" yaml:"fingerprint_envvar,omitempty"`
+	OciPrivateKeyEnvVar     string `json:"private_key_envvar,omitempty" yaml:"private_key_envvar,omitempty"`
+	OciPrivateKeyPathEnvVar string `json:"private_key_path_envvar,omitempty" yaml:"private_key_path_envvar,omitempty"`
+	OciPassphraseEnvVar     string `json:"passphrase_envvar,omitempty" yaml:"passphrase_envvar,omitempty"`
+	OciRegionEnvVar         string `json:"region_envvar,omitempty" yaml:"region_envvar,omitempty"`
+}
+
+func (qt standardAuthDTO) GetOciTenancyOCIDEnvVar() string {
+	return qt.OciTenancyOCIDEnvVar
+}
+
+func (qt standardAuthDTO) GetOciUserOCIDEnvVar() string {
+	return qt.OciUserOCIDEnvVar
+}
+
+func (qt standardAuthDTO) GetOciFingerprintEnvVar() string {
+	return qt.OciFingerprintEnvVar
+}
+
+func (qt standardAuthDTO) GetOciPrivateKeyEnvVar() string {
+	return qt.OciPrivateKeyEnvVar
+}
+
+func (qt standardAuthDTO) GetOciPrivateKeyPathEnvVar() string {
+	return qt.OciPrivateKeyPathEnvVar
+}
+
+func (qt standardAuthDTO) GetOciPassphraseEnvVar() string {
+	return qt.OciPassphraseEnvVar
+}
+
+func (qt standardAuthDTO) GetOciRegionEnvVar() string {
+	return qt.OciRegionEnvVar
 }
 
 func (qt standardAuthDTO) GetAccountID() string {

--- a/internal/anysdk/auth_dto.go
+++ b/internal/anysdk/auth_dto.go
@@ -88,13 +88,17 @@ type standardAuthDTO struct {
 	// needs no runtime auth context at all. Only indirections are accepted
 	// at doc level - literal credential values belong exclusively in the
 	// runtime auth context.
+	// Key naming: every property carries an OCI reference at the operator
+	// surface (tenancy_ocid/user_ocid via "ocid", the rest via an oci_
+	// prefix) so generic terms (fingerprint, private key, passphrase) stay
+	// available to other auth types without collision.
 	OciTenancyOCIDEnvVar    string `json:"tenancy_ocid_envvar,omitempty" yaml:"tenancy_ocid_envvar,omitempty"`
 	OciUserOCIDEnvVar       string `json:"user_ocid_envvar,omitempty" yaml:"user_ocid_envvar,omitempty"`
-	OciFingerprintEnvVar    string `json:"fingerprint_envvar,omitempty" yaml:"fingerprint_envvar,omitempty"`
-	OciPrivateKeyEnvVar     string `json:"private_key_envvar,omitempty" yaml:"private_key_envvar,omitempty"`
-	OciPrivateKeyPathEnvVar string `json:"private_key_path_envvar,omitempty" yaml:"private_key_path_envvar,omitempty"`
-	OciPassphraseEnvVar     string `json:"passphrase_envvar,omitempty" yaml:"passphrase_envvar,omitempty"`
-	OciRegionEnvVar         string `json:"region_envvar,omitempty" yaml:"region_envvar,omitempty"`
+	OciFingerprintEnvVar    string `json:"oci_fingerprint_envvar,omitempty" yaml:"oci_fingerprint_envvar,omitempty"`
+	OciPrivateKeyEnvVar     string `json:"oci_private_key_envvar,omitempty" yaml:"oci_private_key_envvar,omitempty"`
+	OciPrivateKeyPathEnvVar string `json:"oci_private_key_path_envvar,omitempty" yaml:"oci_private_key_path_envvar,omitempty"`
+	OciPassphraseEnvVar     string `json:"oci_passphrase_envvar,omitempty" yaml:"oci_passphrase_envvar,omitempty"`
+	OciRegionEnvVar         string `json:"oci_region_envvar,omitempty" yaml:"oci_region_envvar,omitempty"`
 }
 
 func (qt standardAuthDTO) GetOciTenancyOCIDEnvVar() string {

--- a/internal/anysdk/operation_store.go
+++ b/internal/anysdk/operation_store.go
@@ -1735,14 +1735,21 @@ func (op *standardOpenAPIOperationStore) parameterize(prov Provider, parentDoc S
 	// TODO: clean up
 	sv = strings.TrimSuffix(sv, "/")
 	path := replaceSimpleStringVars(fmt.Sprintf("%s%s", sv, op.OperationRef.extractPathItem()), pathParams)
-	u, err := url.Parse(fmt.Sprintf("%s?%s", path, q.Encode()))
-	if strings.Contains(path, "?") {
-		if len(q) > 0 {
-			u, err = url.Parse(fmt.Sprintf("%s&%s", path, q.Encode()))
-		} else {
-			u, err = url.Parse(path)
+	// Never emit a dangling "?" for an empty query: url.Parse records it as
+	// ForceQuery and reproduces it on the wire, and signature schemes that
+	// cover (request-target) then fail against servers that normalise the
+	// request line before verification (OCI 401 NotAuthenticated on every
+	// no-query body verb).
+	encodedQuery := q.Encode()
+	rawURL := path
+	if encodedQuery != "" {
+		separator := "?"
+		if strings.Contains(path, "?") {
+			separator = "&"
 		}
+		rawURL = fmt.Sprintf("%s%s%s", path, separator, encodedQuery)
 	}
+	u, err := url.Parse(rawURL)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/authsurface/surface.go
+++ b/pkg/authsurface/surface.go
@@ -33,4 +33,11 @@ type AuthDTO interface {
 	GetAuthStyle() int
 	GetAccountID() string
 	GetAccountIDEnvVar() string
+	GetOciTenancyOCIDEnvVar() string
+	GetOciUserOCIDEnvVar() string
+	GetOciFingerprintEnvVar() string
+	GetOciPrivateKeyEnvVar() string
+	GetOciPrivateKeyPathEnvVar() string
+	GetOciPassphraseEnvVar() string
+	GetOciRegionEnvVar() string
 }

--- a/public/formulation/interfaces.go
+++ b/public/formulation/interfaces.go
@@ -768,6 +768,13 @@ type AuthDTO interface {
 	GetKeyIDEnvVar() string
 	GetLocation() string
 	GetName() string
+	GetOciFingerprintEnvVar() string
+	GetOciPassphraseEnvVar() string
+	GetOciPrivateKeyEnvVar() string
+	GetOciPrivateKeyPathEnvVar() string
+	GetOciRegionEnvVar() string
+	GetOciTenancyOCIDEnvVar() string
+	GetOciUserOCIDEnvVar() string
 	GetScopes() []string
 	GetSubject() string
 	GetSuccessor() (AuthDTO, bool)

--- a/public/formulation/wrappers.go
+++ b/public/formulation/wrappers.go
@@ -2631,6 +2631,34 @@ type wrappedAuthDTO struct {
 	inner authsurface.AuthDTO
 }
 
+func (w *wrappedAuthDTO) GetOciTenancyOCIDEnvVar() string {
+	return w.inner.GetOciTenancyOCIDEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciUserOCIDEnvVar() string {
+	return w.inner.GetOciUserOCIDEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciFingerprintEnvVar() string {
+	return w.inner.GetOciFingerprintEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciPrivateKeyEnvVar() string {
+	return w.inner.GetOciPrivateKeyEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciPrivateKeyPathEnvVar() string {
+	return w.inner.GetOciPrivateKeyPathEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciPassphraseEnvVar() string {
+	return w.inner.GetOciPassphraseEnvVar()
+}
+
+func (w *wrappedAuthDTO) GetOciRegionEnvVar() string {
+	return w.inner.GetOciRegionEnvVar()
+}
+
 func (w *wrappedAuthDTO) GetAccountID() string {
 	r0 := w.inner.GetAccountID()
 	return r0


### PR DESCRIPTION
Two changes, bundled because both gate the `oci` provider release: the first is required for any
OCI write operation to work at all, the second enables zero-config auth from the provider doc.

## 1. Never emit a dangling `?` for an empty query string (fix)

`operation_store.go` built every request URL as `path + "?" + query` even when the encoded query
was empty. `url.Parse` records the trailing `?` as `ForceQuery` and reproduces it on the wire and
inside the signed `(request-target)`. Servers that normalise the request line before signature
verification then reconstruct `post /20160918/vcns` against a signature over
`post /20160918/vcns?` -> verification fails. Live OCI rejects every no-query body verb with
`401 NotAuthenticated / Failed to verify the HTTP(S) Signature`; GETs escape because OCI list
calls always carry real query params (`?compartmentId=...`).

Signed-mock suites cannot catch this class of defect: the dangling `?` is self-consistent between
signing and wire, so digest and signed-header checks all pass. It was found by bisecting a live
failure (official-SDK signer probe succeeded where the engine failed) and confirmed with a raw
header/URL dump at the mock.

The fix appends `?` (or `&` for paths with embedded queries) only when the encoded query is
non-empty:

~~~go
encodedQuery := q.Encode()
rawURL := path
if encodedQuery != "" {
    separator := "?"
    if strings.Contains(path, "?") {
        separator = "&"
    }
    rawURL = fmt.Sprintf("%s%s%s", path, separator, encodedQuery)
}
u, err := url.Parse(rawURL)
~~~

## 2. Doc-level OCI env var indirections for `oci_signing_v1` (feat)

A provider doc may now ship default env var names in its `config.auth` block, so a populated
environment needs no runtime `--auth` context - matching the `credentialsenvvar` convention of
the API-key auth types:

~~~yaml
config:
  auth:
    type: oci_signing_v1
    tenancy_ocid_envvar: OCI_TENANCY
    user_ocid_envvar: OCI_USER
    oci_fingerprint_envvar: OCI_FINGERPRINT
    oci_private_key_path_envvar: OCI_KEY_FILE
    oci_passphrase_envvar: OCI_PASSPHRASE
~~~

Key set: `tenancy_ocid_envvar`, `user_ocid_envvar`, `oci_fingerprint_envvar`, `oci_private_key_envvar`,
`oci_private_key_path_envvar`, `oci_passphrase_envvar`, `oci_region_envvar`. Indirections only - literal
credential values remain runtime-auth-context territory. Plumbed through
`internal/anysdk/auth_dto.go`, `pkg/authsurface.AuthDTO` and the `public/formulation` wrapper
(new getters `GetOci*EnvVar()`); the API growth check is unaffected (methods on existing
interfaces, no new exported types). The consumer wire-through (mapping the doc-level getters onto
the runtime `AuthCtx` in `transformOpenapiStackqlAuthToLocal`) is tracked as a stackql issue.

## Verification

- `go build ./...` and `go vet` clean (vet findings in `registry.go` are pre-existing).
- Consumed by a local stackql build (`go.mod` replace) and verified against a live OCI Always
  Free tenancy (`ap-melbourne-1`): 18/18 smoke assertions including the full instance state walk
  (launch -> RUNNING -> STOP -> STOPPED -> START -> RUNNING -> rename -> terminate ->
  TERMINATED), VCN/subnet/bucket lifecycles, and both signed forms (three-header GET/DELETE,
  six-header POST/PUT).
- The oci provider's signed-mock integration suite (26 checks) now rejects a dangling `?` exactly
  as live OCI does, so a regression fails the suite rather than only surfacing live.

## Release

Suggest cutting `v0.5.4-alpha02` from this branch for the pending stackql release - the oci
provider publish is gated on a released stackql that carries change 1.